### PR TITLE
Patch/mcp 82/GitHub actions errors

### DIFF
--- a/.github/workflows/deploy_mcp.yml
+++ b/.github/workflows/deploy_mcp.yml
@@ -5,14 +5,15 @@ on:
     branches:
       - master
 
+# a comment
 jobs:
-  unit-tests:
+  deployment-tests:
     name: 'Deployment tests'
     runs-on: ubuntu-latest
 
     env:
       working-directory: ./tests/mcp/deployment
-      GCP_PROJECT_ID: "mcpdeploytest-${GITHUB_SHA::8}"
+      GCP_PROJECT_ID: "mcpdeploytest-${GITHUB_SHA::8}-${GITHUB_RUN_NUMBER}"
 
     defaults:
       run:
@@ -89,8 +90,8 @@ jobs:
       - name: setup kubectl
         run: |
           gcloud components install kubectl
-          gcloud container clusters create mcpdeploytest-cluster --num-nodes=1
-          gcloud container clusters get-credentials mcpdeploytest-cluster
+          gcloud container clusters create mcpdeploytest-cluster --num-nodes=1 --zone=europe-west2-a --node-locations=europe-west2-a,europe-west2-c
+          gcloud container clusters get-credentials mcpdeploytest-cluster --zone=europe-west2-a
 
       # Setup main.tf, deploy and destroy k8s
       - name: deploy k8s

--- a/tests/mcp/deployment/k8s/k8s.yml
+++ b/tests/mcp/deployment/k8s/k8s.yml
@@ -5,25 +5,21 @@ components:
     app_1:
       deployment:
         metadata:
-          name: "mosquitto"
-          namespace:
+          name: terraform-example
           labels:
-            app: "mosquitto"
+            test: "ExampleApp"
         spec:
-          replicas: 1
           selector:
             match_labels:
-              app: "mosquitto"
+              test: "ExampleApp"
           template:
             metadata:
               labels:
-                app: "mosquitto"
+                test: "ExampleApp"
             spec:
               container:
-                - name: "mosquitto"
-                  image: "eclipse-mosquitto:1.6.2"
-                  port:
-                    - container_port: 1883
+                - image: "nginx:1.7.8"
+                  name: "example"
                   resources:
                     limits:
                       cpu: "0.5"
@@ -31,36 +27,24 @@ components:
                     requests:
                       cpu: "250m"
                       memory: "50Mi"
-                  volume_mount:
-                    - name: mosquitto-secret-file
-                      mount_path: /mosquitto/secret
-                    - name: mosquitto-config-file
-                      mount_path: mosquitto/config
-                - name: "tomcat-example"
-                  image: "tomcat:8.5-jdk8-adoptopenjdk-openj9"
-                  port:
-                    - container_port: 8080
-                  resources:
-                    limits:
-                      cpu: "0.5"
-                      memory: "512Mi"
-                    requests:
-                      cpu: "250m"
-                      memory: "50Mi"
-              volume:
-                - name: mosquitto-config-file
-                  config_map:
-                    name: mosquitto-config-file
-                - name: mosquitto-secret-file
-                  secret:
-                    secret_name: mosquitto-secret-file
+                  liveness_probe:
+                    http_get:
+                      path: "/nginx_status"
+                      port: 80
+                      http_header:
+                        name: "X-Custom-Header"
+                        value: "Awesome"
+                    initial_delay_seconds: 3
+                    period_seconds: 3
+
       config_map:
         metadata:
-          name: "mosquitto-config-file"
+          name: "config"
           labels:
             env: "test"
         data:
-          'test': 'test'
+          api_host: "myhost:433"
+          db_host: "dbhost:5432"
         data_file:
           - ../resources/mosquitto.conf
         binary_data:
@@ -69,36 +53,21 @@ components:
           - ../resources/binary.bin
       secret:
         metadata:
-          annotations:
-            key1:
-            key2:
-          name: "mosquitto-secret-file"
-          namespace:
-          labels:
-            env: "test"
-        type: Opaque
+          name: "basic-auth"
+        type: "kubernetes.io/basic-auth"
         data:
-          login: login
-          password: password
-        data_file:
-          - ../resources/secret.file
+          username: "admin"
+          password: "password"
       service:
         metadata:
-          name: "mosquitto"
-          namespace:
-          labels:
-            env: "test"
-          generate_name:
+          name: "terraform-example"
         spec:
+          session_affinity: "ClientIP"
           selector:
-            app: "mosquitto"
+            app: "terraform-example"
           port:
-            - name: "mosquitto-listener"
-              port: 1883
-              target_port: 1883
-            - name: "tomcat-listener"
-              port: 80
-              target_port: 8080
+            - port: 8080
+              target_port: 80
           type: LoadBalancer
     app_2:
       pod_autoscaler:
@@ -133,6 +102,7 @@ components:
               image: "nginx:1.7.8"
               port:
                 - container_port: 80
+
       service_account:
         metadata:
           name: "pod-app-service-account"
@@ -190,6 +160,7 @@ components:
                         value: Awesome
                     initial_delay_seconds: 3
                     period_seconds: 3
+
     app_4:
       k8s_persistent_volume_claim:
         metadata:

--- a/tests/mcp/deployment/k8s/k8s.yml
+++ b/tests/mcp/deployment/k8s/k8s.yml
@@ -5,21 +5,25 @@ components:
     app_1:
       deployment:
         metadata:
-          name: terraform-example
+          name: "mosquitto"
+          namespace:
           labels:
-            test: "ExampleApp"
+            app: "mosquitto"
         spec:
+          replicas: 1
           selector:
             match_labels:
-              test: "ExampleApp"
+              app: "mosquitto"
           template:
             metadata:
               labels:
-                test: "ExampleApp"
+                app: "mosquitto"
             spec:
               container:
-                - image: "nginx:1.7.8"
-                  name: "example"
+                - name: "mosquitto"
+                  image: "eclipse-mosquitto:1.6.2"
+                  port:
+                    - container_port: 1883
                   resources:
                     limits:
                       cpu: "0.5"
@@ -27,24 +31,36 @@ components:
                     requests:
                       cpu: "250m"
                       memory: "50Mi"
-                  liveness_probe:
-                    http_get:
-                      path: "/nginx_status"
-                      port: 80
-                      http_header:
-                        name: "X-Custom-Header"
-                        value: "Awesome"
-                    initial_delay_seconds: 3
-                    period_seconds: 3
-
+                  volume_mount:
+                    - name: mosquitto-secret-file
+                      mount_path: /mosquitto/secret
+                    - name: mosquitto-config-file
+                      mount_path: mosquitto/config
+                - name: "tomcat-example"
+                  image: "tomcat:8.5-jdk8-adoptopenjdk-openj9"
+                  port:
+                    - container_port: 8080
+                  resources:
+                    limits:
+                      cpu: "0.5"
+                      memory: "512Mi"
+                    requests:
+                      cpu: "250m"
+                      memory: "50Mi"
+              volume:
+                - name: mosquitto-config-file
+                  config_map:
+                    name: mosquitto-config-file
+                - name: mosquitto-secret-file
+                  secret:
+                    secret_name: mosquitto-secret-file
       config_map:
         metadata:
-          name: "config"
+          name: "mosquitto-config-file"
           labels:
             env: "test"
         data:
-          api_host: "myhost:433"
-          db_host: "dbhost:5432"
+          'test': 'test'
         data_file:
           - ../resources/mosquitto.conf
         binary_data:
@@ -53,21 +69,36 @@ components:
           - ../resources/binary.bin
       secret:
         metadata:
-          name: "basic-auth"
-        type: "kubernetes.io/basic-auth"
+          annotations:
+            key1:
+            key2:
+          name: "mosquitto-secret-file"
+          namespace:
+          labels:
+            env: "test"
+        type: Opaque
         data:
-          username: "admin"
-          password: "password"
+          login: login
+          password: password
+        data_file:
+          - ../resources/secret.file
       service:
         metadata:
-          name: "terraform-example"
+          name: "mosquitto"
+          namespace:
+          labels:
+            env: "test"
+          generate_name:
         spec:
-          session_affinity: "ClientIP"
           selector:
-            app: "terraform-example"
+            app: "mosquitto"
           port:
-            - port: 8080
-              target_port: 80
+            - name: "mosquitto-listener"
+              port: 1883
+              target_port: 1883
+            - name: "tomcat-listener"
+              port: 80
+              target_port: 8080
           type: LoadBalancer
     app_2:
       pod_autoscaler:


### PR DESCRIPTION
Seems to be an issue with zone `europe-west2-b` specifically. But specifying `--zone=europe-west2-<a or c>` would still result in an error for `kubernetes_deployment`. It would say ` Waiting for rollout to finish: 0 of 1 updated replicas are available...` and when looking in gke workloads, there would be an error related to the workload not have minimum availability.

The only change I found that seemed to fix this was specifying `--node-locations` to being both `europe-west2-a` and `europe-west2-c` when creating the cluster. 