### PR TITLE
Bug/ae deployment fail

### DIFF
--- a/.github/workflows/deploy_mcp.yml
+++ b/.github/workflows/deploy_mcp.yml
@@ -14,7 +14,7 @@ jobs:
 
     env:
       working-directory: ./tests/mcp/deployment
-      GCP_PROJECT_ID: "mcpdeploytest-${GITHUB_SHA::8}-${GITHUB_RUN_NUMBER}"
+      GCP_PROJECT_ID: "mcpdeploytest-${GITHUB_SHA::8}"
       KUBE_CONFIG_PATH: ~/.kube/config
 
     defaults:
@@ -56,6 +56,7 @@ jobs:
           gcloud services enable cloudbuild.googleapis.com
           gcloud services enable container.googleapis.com
           gcloud services enable appengine.googleapis.com
+          gcloud services enable appengineflex.googleapis.com
           gcloud services enable artifactregistry.googleapis.com
           gcloud services enable run.googleapis.com
           gcloud config set compute/zone europe-west2

--- a/mcp/docs/GCP_APP_ENGINE.md
+++ b/mcp/docs/GCP_APP_ENGINE.md
@@ -93,7 +93,7 @@ The key `bucket_name` is the name of the bucket which holds the services files.
 | `location_id` | string | true | The geographical location to serve the app from | none |
 | `auth_domain` | string | false | The domain to authenticate users with when using App Engine's User API | none |
 | `serving_status` | enum | false | The serving status of the app. Options are SERVING and STOPPED | none |
-| `sa_delay` | string | false | Delay creation of flexible app after creation of service account to avoid propagation error | "30s" |
+| `flex_delay` | string | false | Delay creation of flexible app after creation of service account to avoid propagation error | "30s" |
 | `iap` | map | false | Settings for enabling Cloud Identity Aware Proxy. If iap map exists, the `oauth2_client_id` and `oauth2_client_secret` fields must be non-empty.  | none |
 | `iap.enabled` | boolean | true within IAP context only | IAP enabled or not. | `false` |
 | `iap.oauth2_client_id` | string | true within IAP context only | OAuth2 client ID to use for the authentication flow | none |
@@ -264,13 +264,13 @@ P4SA (Per-Product Per-Project Service Account) refers to the google managed serv
 The error means that a GAIA (Google Account and ID Administration) ID has not yet been associated with the service account for this project.   
 A default of 30s has been added between the creation of the service account and creation of flexible app service, 
 to ensure the service account has been created before app engine attempts to use it.  
-If this error occurs set `sa_delay` to `"2m"` or more. E.g.
+If this error occurs set `flex_delay` to `"2m"` or more. E.g.
 
 ```yaml
 project_id: project
 create_google_project: false
 location_id: "europe-west2"
-sa_delay: "2m"     
+flex_delay: "2m"     
 components:
   specs:
     default:

--- a/mcp/docs/GCP_APP_ENGINE.md
+++ b/mcp/docs/GCP_APP_ENGINE.md
@@ -93,6 +93,7 @@ The key `bucket_name` is the name of the bucket which holds the services files.
 | `location_id` | string | true | The geographical location to serve the app from | none |
 | `auth_domain` | string | false | The domain to authenticate users with when using App Engine's User API | none |
 | `serving_status` | enum | false | The serving status of the app. Options are SERVING and STOPPED | none |
+| `sa_delay` | string | false | Delay creation of flexible app after creation of service account to avoid propagation error | "30s" |
 | `iap` | map | false | Settings for enabling Cloud Identity Aware Proxy. If iap map exists, the `oauth2_client_id` and `oauth2_client_secret` fields must be non-empty.  | none |
 | `iap.enabled` | boolean | true within IAP context only | IAP enabled or not. | `false` |
 | `iap.oauth2_client_id` | string | true within IAP context only | OAuth2 client ID to use for the authentication flow | none |
@@ -256,4 +257,22 @@ gcp_ae.yml probably has a `common:` key with no values. I.e.
 components:
   common:
   specs:
+```
+####  Error 404: Unable to retrieve P4SA: [service-<project_number>@gcp-gae-service.iam.gserviceaccount.com] from GAIA. Could be GAIA propagation delay or request from deleted apps.  
+This is most often a propogation delay with creation of service account for app engine.   
+P4SA (Per-Product Per-Project Service Account) refers to the google managed service account for app engine.
+The error means that a GAIA (Google Account and ID Administration) ID has not yet been associated with the service account for this project.   
+A default of 30s has been added between the creation of the service account and creation of flexible app service, 
+to ensure the service account has been created before app engine attempts to use it.  
+If this error occurs set `sa_delay` to `"2m"` or more. E.g.
+
+```yaml
+project_id: project
+create_google_project: false
+location_id: "europe-west2"
+sa_delay: "2m"     
+components:
+  specs:
+    default:
+      ...
 ```

--- a/mcp/gcp_ae.tf
+++ b/mcp/gcp_ae.tf
@@ -15,8 +15,6 @@ data "google_organization" "self" {
 }
 
 
-
-
 //noinspection HILUnresolvedReference
 resource "google_project" "self" {
   count = lookup(local.gae, "create_google_project", false) ? 1 : 0
@@ -52,7 +50,7 @@ resource "google_project_service" "std" {
 //noinspection HILUnresolvedReference
 resource "google_app_engine_application" "self" {
   count = local.gae == {} ? 0 : 1
-  project = length(local.as_flex_specs) > 0 ? google_project_service.flex.0.project : google_project_service.std.0.project
+  project = length(local.as_flex_specs) > 0 ? google_project_iam_member.gae_api.0.project : google_project_service.std.0.project
   location_id = lookup(local.gae, "location_id", null)
   auth_domain = lookup(local.gae, "auth_domain", null)
   serving_status = lookup(local.gae, "serving_status", null)
@@ -81,6 +79,14 @@ resource "google_app_engine_application" "self" {
 }
 
 
+resource "time_sleep" "flex_sa_propagation" {
+  count = length(local.as_flex_specs) > 0 ? 1: 0
+  create_duration = lookup(local.gae, "sa_delay", "30s")
+  triggers ={
+    project_id = google_project_iam_member.gae_api.0.project
+  }
+}
+
 resource "google_project_iam_member" "gae_api" {
   count = length(local.as_flex_specs) > 0 ? 1 : 0
   # force dependency on the APIs being enabled
@@ -93,10 +99,11 @@ resource "google_project_iam_member" "gae_api" {
 
 //noinspection HILUnresolvedReference
 resource "google_app_engine_flexible_app_version" "self" {
+  provider = google-beta
   for_each = local.as_flex_specs
   # force dependency on the required service account being created and given permission to operate
 
-  project = google_project_iam_member.gae_api.0.project
+  project = time_sleep.flex_sa_propagation.0.triggers["project_id"]
   version_id = lookup(each.value, "version_id", lookup(local.project, "version", "v1"))
   service = lookup(each.value, "service", each.key)
   runtime = lookup(each.value, "runtime", null)
@@ -179,6 +186,7 @@ resource "google_app_engine_flexible_app_version" "self" {
       min_idle_instances = lookup(automatic_scaling.value, "min_idle_instances", null)
       min_pending_latency = lookup(automatic_scaling.value, "min_pending_latency", null)
       min_total_instances = lookup(automatic_scaling.value, "min_total_instances", null)
+      //noinspection HILUnresolvedReference
       dynamic "cpu_utilization"{
         for_each = lookup(automatic_scaling.value, "cpu_utilization", null) == null ? {cpu_utilization: {target_utilization: local.default.automatic_scaling.target_utilization}} : {cpu_utilization: automatic_scaling.value.cpu_utilization}
         //noinspection HILUnresolvedReference
@@ -230,7 +238,7 @@ resource "google_app_engine_flexible_app_version" "self" {
     for_each = lookup(each.value, "manual_scaling", null) == null ? {} : {manual_scaling: each.value.manual_scaling}
 
     content {
-      instances = lookup(manual_scaling.value, "instances", null)
+      instances = lookup(manual_scaling.value, "instances", 1)
     }
   }
 

--- a/mcp/gcp_ae.tf
+++ b/mcp/gcp_ae.tf
@@ -81,7 +81,7 @@ resource "google_app_engine_application" "self" {
 
 resource "time_sleep" "flex_sa_propagation" {
   count = length(local.as_flex_specs) > 0 ? 1: 0
-  create_duration = lookup(local.gae, "sa_delay", "30s")
+  create_duration = lookup(local.gae, "flex_delay", "30s")
   triggers ={
     project_id = google_project_iam_member.gae_api.0.project
   }

--- a/tests/mcp/deployment/GCP/gcp_ae.yml
+++ b/tests/mcp/deployment/GCP/gcp_ae.yml
@@ -1,6 +1,7 @@
 project_id: &project_id <project_id>
 create_google_project: false
 location_id: "europe-west2"
+terraform_delay: "2m"
 components:
   common:
     entrypoint: python main.py
@@ -8,7 +9,8 @@ components:
     env: flex
   specs:
     default:
-      automatic_scaling: {}
+      manual_scaling:
+        instance: 1
       deployment:
         container:
           image: <image_uri>

--- a/tests/mcp/deployment/GCP/gcp_ae.yml
+++ b/tests/mcp/deployment/GCP/gcp_ae.yml
@@ -1,7 +1,7 @@
 project_id: &project_id <project_id>
 create_google_project: false
 location_id: "europe-west2"
-terraform_delay: "2m"
+flex_delay: "2m"
 components:
   common:
     entrypoint: python main.py


### PR DESCRIPTION
* Changed order of depedencies
* Added `time_sleep` resource to make delay before creating flexible app. Defaults to `30s` but can be changed using `flex_delay` key in `gcp_ae.yml`. Deployment tests will use "2m"
* Updated documentation
* Removed `${GITHUB_RUN_NUMBER}` from project name because it doesn't update if re-running job, so doesn't work as it was intended
* Changed to using `manual_scaling` because `automatic_scaling` would often have a `RESOURCE_EXHAUSTED` error to do with the quota for GCE

`kubernetes_deloyment` still fails occasionally, and am not sure how to keep that consistent