### PR TITLE
INFRA-45 Add Deployment test for perimeter and unit tests for secure swarm

### DIFF
--- a/.github/workflows/deploy_gcp_vpc.yml
+++ b/.github/workflows/deploy_gcp_vpc.yml
@@ -1,0 +1,81 @@
+  name: 'GCP VPC Deployment Tests'
+  on:
+    push:
+      branches:
+        - main
+        - develop
+  jobs:
+    deployment-tests:
+      name: 'Deployment tests'
+      runs-on: ubuntu-latest
+
+      env:
+        working-directory: ./tests/gcp/deployment
+        NEW_PROJECT_ID: "${GITHUB_REF##*/}-${GITHUB_SHA::*}"
+
+      defaults:
+        run:
+          shell: bash
+          working-directory: ${{env.working-directory}}
+
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+
+
+        - name: Setup Terraform
+          uses: hashicorp/setup-terraform@v1
+          with:
+            terraform_wrapper: false
+
+        # Install gcloud sdk and set the service account
+        - name: Setup Cloud SDK
+          uses: google-github-actions/setup-gcloud@master
+          with:
+            service_account_key: ${{secrets.GCP_SA_KEY}}
+            export_default_credentials: true
+
+        - name: Install Python
+          uses: actions/setup-python@v2
+          with:
+            python-version: '3.x'
+
+        - name: Validate Yaml
+          run: |
+            python -m pip install --upgrade pip
+            pip install PyYAML jsonschema
+            cd access_context_manager/yaml_validation
+            python yaml_validation.py
+
+        - name: Setup GCP
+          run: |
+            gcloud projects create "${{env.NEW_PROJECT_ID}}-1" --folder=${{secrets.GCP_FOLDER_ID}} --set-as-default
+            gcloud beta billing projects link ${{env.NEW_PROJECT_ID}}-1 --billing-account=${{secrets.GCP_BILLING_ID}}
+            gcloud services enable cloudresourcemanager.googleapis.com
+            gcloud projects create "${{env.NEW_PROJECT_ID}}-2" --folder=${{secrets.GCP_FOLDER_ID}} --set-as-default
+            gcloud beta billing projects link ${{env.NEW_PROJECT_ID}}-2 --billing-account=${{secrets.GCP_BILLING_ID}}
+            gcloud services enable cloudresourcemanager.googleapis.com
+            gcloud config set compute/zone europe-west2-a
+
+        - name: Configure files
+          run: |
+            cd access_context_manager
+            sed -i "s/access-policy-name/${{secrets.ACCESS_POLICY}}/" main.tf
+            sed -i "s/resources-list/[${{secrets.ACCESS_POLICY}}-1,${{secrets.ACCESS_POLICY}}-2]/" main.tf
+            sed -i "s/source-path/..\/..\/..\/..\/..\/gcp\/access_context_manager\/service_perimeter_regular" main.tf
+            sed -i "s/project-1/${{env.NEW_PROJECT_ID}}-1/" ingressPolicies.yml
+            sed -i "s/project-2/${{env.NEW_PROJECT_ID}}-2/" ingressPolicies.yml
+
+        - name: Deploy perimeter
+          run: |
+            cd access_context_manager
+            terraform init
+            terraform plan -out="./plan.tfplan"
+            terraform apply plan.tfplan
+
+
+        - name: delete projects
+          if : ${{ always() }}
+          run: |
+            gcloud projects delete ${{env.GCP_PROJECT_ID}}-1
+            gcloud projects delete ${{env.GCP_PROJECT_ID}}-2

--- a/gcp/secure_swarm_node/locals.tf
+++ b/gcp/secure_swarm_node/locals.tf
@@ -1,6 +1,4 @@
 locals {
-  service_account_email = var.service_account_email == "" ? "${data.google_project.default.number}@-compute@developer.gserviceaccount.com" : var.service_account_email
-
   blue_instance_template = lookup(var.blue_instance_template, "security_level", null) == null ? merge(
     var.blue_instance_template, { security_level = var.security_level
   }) : contains(["secure-1", "confidential-1"], var.blue_instance_template["security_level"]) ? var.blue_instance_template : merge(var.blue_instance_template, { security_level = "confidential-1" })

--- a/gcp/secure_swarm_node/main.tf
+++ b/gcp/secure_swarm_node/main.tf
@@ -3,6 +3,7 @@ terraform {
   experiments = [module_variable_optional_attrs]
 }
 
+
 data google_project default {
   project_id = var.project
 }
@@ -11,6 +12,10 @@ data google_compute_health_check self {
   for_each = {for health_check in var.health_check : health_check.name => health_check}
   name     = each.key
   project  = var.project
+}
+
+locals {
+  service_account_email = var.service_account_email == "" ? "${data.google_project.default.number}@-compute@developer.gserviceaccount.com" : var.service_account_email
 }
 
 //Updates the time for the version when the template is updated or certain properties of MIG are updated

--- a/tests/gcp/deployment/access_context_manager/ingressPolicies.yml
+++ b/tests/gcp/deployment/access_context_manager/ingressPolicies.yml
@@ -1,0 +1,11 @@
+ingressPolicies:
+  - ingressFrom:
+      identityType: ANY_IDENTITY
+      sources:
+        - resource: projects/project-1
+        - accessLevel: projects/project-2
+    ingressTo:
+      operations:
+        - serviceName: '*'
+      resources:
+        - '*'

--- a/tests/gcp/deployment/access_context_manager/main.tf
+++ b/tests/gcp/deployment/access_context_manager/main.tf
@@ -1,0 +1,8 @@
+module regular_service_perimeter {
+  source = "source-path"
+  name = "test-perimeter"
+  access_policy_name = "access-policy-name"
+  ingress_file_path = "./ingressPolicies.yml"
+  egress_file_path = "./egressPolicies.yml"
+  resources = resources-list
+}

--- a/tests/gcp/deployment/access_context_manager/yaml_validation/schema.json
+++ b/tests/gcp/deployment/access_context_manager/yaml_validation/schema.json
@@ -1,0 +1,136 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "type": "object",
+    "properties": {
+        "ingressPolicies": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ingressFrom": {
+                        "type": "object",
+                        "properties": {
+                            "identityType": {
+                                "type": "string"
+                            },
+                            "identities": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "sources": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "access_level": {
+                                            "type": "string"
+                                        },
+                                        "resource": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "ingressTo": {
+                        "type": "object",
+                        "properties": {
+                            "operations": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "serviceName": {
+                                            "type": "string"
+                                        },
+                                        "methodSelectors": {
+                                            "type": "object",
+                                            "properties": {
+                                                "method": {
+                                                    "type": "string"
+                                                },
+                                                "permission": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "resources": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "egressPolicies": {
+            "type": [
+                "array",
+                "null"
+            ],
+            "items": {
+                "type": "object",
+                "properties": {
+                    "egressFrom": {
+                        "type": "object",
+                        "properties": {
+                            "identityType": {
+                                "type": "string"
+                            },
+                            "identities": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "egressTo": {
+                        "type": "object",
+                        "properties": {
+                            "operations": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "serviceName": {
+                                            "type": "string"
+                                        },
+                                        "methodSelectors": {
+                                            "type": "object",
+                                            "properties": {
+                                                "method": {
+                                                    "type": "string"
+                                                },
+                                                "permission": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "resources": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/gcp/deployment/access_context_manager/yaml_validation/yaml_validation.py
+++ b/tests/gcp/deployment/access_context_manager/yaml_validation/yaml_validation.py
@@ -1,0 +1,26 @@
+from jsonschema import validate
+import json
+import yaml
+import os
+
+
+valid = True
+#Load Schema
+with open('schema.json') as file:
+    schema = json.load(file)
+
+#Test ingress file
+if os.path.exists("../ingressPolicies.yml"):
+    with open('../ingressPolicies.yml') as ingress_file:
+        ingress_yml = yaml.load(ingress_file, Loader=yaml.FullLoader)
+        validate(instance=ingress_yml, schema=schema)
+        print("VALID")
+            
+
+#Test egress file
+if os.path.exists("../egressPolicies.yml"):
+    with open('../egressPolicies.yml') as ingress_file:
+        ingress_yml = yaml.load(ingress_file, Loader=yaml.FullLoader)
+        validate(instance=ingress_yml, schema=schema)
+        print("VALID")
+        

--- a/tests/gcp/unit_tests/secure_swarm_node/locals.tf
+++ b/tests/gcp/unit_tests/secure_swarm_node/locals.tf
@@ -1,0 +1,1 @@
+../../../../gcp/secure_swarm_node/locals.tf

--- a/tests/gcp/unit_tests/secure_swarm_node/main.tf
+++ b/tests/gcp/unit_tests/secure_swarm_node/main.tf
@@ -1,0 +1,17 @@
+data external test_blue_instance_template{
+  query = {"security_level" = local.blue_instance_template.security_level}
+  program = ["python", "${path.module}/test_blue_instance_template.py"]
+}
+
+output test_blue_instance_template {
+  value = data.external.test_blue_instance_template.result
+}
+
+data external test_green_instance_template{
+  query = {"security_level" = local.blue_instance_template.security_level}
+  program = ["python", "${path.module}/test_blue_instance_template.py"]
+}
+
+output test_green_instance_template {
+  value = data.external.test_green_instance_template.result
+}

--- a/tests/gcp/unit_tests/secure_swarm_node/test_blue_instance_template.py
+++ b/tests/gcp/unit_tests/secure_swarm_node/test_blue_instance_template.py
@@ -1,0 +1,19 @@
+from sys import path, stderr
+
+try:
+    path.insert(1, '../../../test_fixtures/python_validator')
+    from python_validator import python_validator
+except Exception as e:
+    print(e, stderr)
+
+"""
+    Tests the configuration of security level for blue instance template.
+"""
+
+expected_data = {
+    "security_level": "secure-2"
+}
+
+
+if __name__ == '__main__':
+    python_validator(expected_data)

--- a/tests/gcp/unit_tests/secure_swarm_node/test_green_instance_template.py
+++ b/tests/gcp/unit_tests/secure_swarm_node/test_green_instance_template.py
@@ -1,0 +1,19 @@
+from sys import path, stderr
+
+try:
+    path.insert(1, '../../../test_fixtures/python_validator')
+    from python_validator import python_validator
+except Exception as e:
+    print(e, stderr)
+
+"""
+    Tests the configuration of security level for green instance template.
+"""
+
+expected_data = {
+    "security_level": "confidential-1"
+}
+
+
+if __name__ == '__main__':
+    python_validator(expected_data)

--- a/tests/gcp/unit_tests/secure_swarm_node/vars.tf
+++ b/tests/gcp/unit_tests/secure_swarm_node/vars.tf
@@ -1,0 +1,13 @@
+variable "blue_instance_template" {
+  default = {}
+}
+
+variable "green_instance_template" {
+  default = {
+    security_level = "confidential-1"
+  }
+}
+
+variable "security_level" {
+  default = "secure-2"
+}


### PR DESCRIPTION
* Added `deploy_gcp_vpc.yml` which has a deployment test for the regular perimeter.
* Google Projects are created in the same folder as the MCP deployment tests (based on the GCP_FOLDER_ID secret), and uses the same service account that was used for that test.
* There needs to be a `ACCESS_POLICY` secret, which is the same format as the terraform `access_policy` variable
* Created projects are deleted after deployment.
