### PR TITLE
bug/INFRA-38/stale_vpc_sc_projects

### DIFF
--- a/gcp/access_context_manager/service_perimeter_regular/locals.tf
+++ b/gcp/access_context_manager/service_perimeter_regular/locals.tf
@@ -95,9 +95,4 @@ locals {
                                 "vision.googleapis.com",
                                 "vpcaccess.googleapis.com"
                               ]
-  //noinspection HILUnresolvedReference
-  resources = [
-    for project in data.google_project.self:
-          "projects/${project.number}"
-  ]
 }

--- a/gcp/access_context_manager/service_perimeter_regular/main.tf
+++ b/gcp/access_context_manager/service_perimeter_regular/main.tf
@@ -1,12 +1,16 @@
 resource google_access_context_manager_service_perimeter self {
-  depends_on = [data.google_project.self]
+//  depends_on = [data.google_project.self]
   name = "accessPolicies/${var.access_policy_name}/servicePerimeters/${var.name}"
   parent = "accessPolicies/${var.access_policy_name}"
   title = var.name
   perimeter_type = "PERIMETER_TYPE_REGULAR"
 
   status {
-    resources = local.resources
+    //noinspection HILUnresolvedReference
+    resources = [
+      for project in data.google_project.self:
+        "projects/${project.number}"
+    ]
     restricted_services = local.restricted_services
     access_levels = [ for access_level in var.access_levels : "accessPolicies/${var.access_policy_name}/accessLevels/${access_level}"]
     dynamic vpc_accessible_services {

--- a/gcp/access_context_manager/service_perimeter_regular/main.tf
+++ b/gcp/access_context_manager/service_perimeter_regular/main.tf
@@ -1,5 +1,4 @@
 resource google_access_context_manager_service_perimeter self {
-//  depends_on = [data.google_project.self]
   name = "accessPolicies/${var.access_policy_name}/servicePerimeters/${var.name}"
   parent = "accessPolicies/${var.access_policy_name}"
   title = var.name

--- a/gcp/access_context_manager/service_perimeter_regular/main.tf
+++ b/gcp/access_context_manager/service_perimeter_regular/main.tf
@@ -1,4 +1,5 @@
 resource google_access_context_manager_service_perimeter self {
+  depends_on = [data.google_project.self]
   name = "accessPolicies/${var.access_policy_name}/servicePerimeters/${var.name}"
   parent = "accessPolicies/${var.access_policy_name}"
   title = var.name


### PR DESCRIPTION
Adds a direct dependency between the perimeter resource and data source it uses for project lookups.
Without this, Terraform needs to run twice. One to removed details from state, one to update the resource