### PR TITLE
Disk Snapshot Schedule

### DIFF
--- a/gcp/secure_swarm_node/README.md
+++ b/gcp/secure_swarm_node/README.md
@@ -54,3 +54,26 @@ module "secure_swarm_a" {
   
 }
 ```
+
+
+Disk Snapshot schedule configuration takes one of the following fomats:
+```hcl
+data_disk_snapshot_schedule = {
+  frequency = "hourly" | "daily"
+  interval = number
+  start_time = time
+} 
+
+---------or----------
+
+data_disk_snapshot_schedule = {
+  frequency = "weekly"
+  weekly_snapshot_schedule = [
+    {
+      day = "MONDAY" | "TUESDAY" | ... | "SUNDAY"
+      start_time = time
+    },
+    ...
+  ]
+}
+```

--- a/gcp/secure_swarm_node/README.md
+++ b/gcp/secure_swarm_node/README.md
@@ -5,6 +5,8 @@ and optionally confidential computing enabled.
 
 Each node is configured with:
 * `google_compute_disk` -  persistent storage, with "NVME" as the interface
+* `google_compute_resource_policy` - Creates and attaches a snapshot schedule for the persistent disk.
+Defaults to being run daily at 3:00. See [Terraform Documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_resource_policy) for more details.
 * `secure_instance_template` - Instance Template with shielded VM and optionally confidential computing enabled.
   Uses the previously created `google_compute_disk`
 * `google_compute_instance_manager` - Managed Instance Group, with stateful disk set to never delete

--- a/gcp/secure_swarm_node/main.tf
+++ b/gcp/secure_swarm_node/main.tf
@@ -35,7 +35,7 @@ resource time_static resource_policy_time {
 
 resource google_compute_disk self {
   provider  = google-beta
-  name      = "${var.name}-${var.zone}-disk"
+  name      = "${var.name}-${var.zone}-data"
   zone      = "${var.region}-${var.zone}"
   project   = var.project
   labels    = var.labels

--- a/gcp/secure_swarm_node/main.tf
+++ b/gcp/secure_swarm_node/main.tf
@@ -28,7 +28,7 @@ resource time_static self {
 resource time_static resource_policy_time {
   triggers = {
     snapshot_properties = jsonencode(var.snapshot_properties)
-    daily_schedule = jsonencode(var.data_disk_snapshot_schedule)
+    data_disk_snapshot_schedule = jsonencode(var.data_disk_snapshot_schedule)
     retention_policy = jsonencode(var.retention_policy)
   }
 }

--- a/gcp/secure_swarm_node/main.tf
+++ b/gcp/secure_swarm_node/main.tf
@@ -25,7 +25,7 @@ resource time_static self {
 }
 
 //Updates the google_compute_disk_resource_policy_attachment when google_compute_resource_policy is updated
-resource time_static snapshot {
+resource time_static resource_policy_time {
   triggers = {
     snapshot_properties = jsonencode(var.snapshot_properties)
     daily_schedule = jsonencode(var.data_disk_snapshot_schedule)
@@ -44,7 +44,7 @@ resource google_compute_disk self {
 }
 
 resource google_compute_resource_policy self {
-  name = "${var.name}-${var.zone}-${time_static.snapshot.unix}"
+  name = "${var.name}-${var.zone}-${time_static.resource_policy_time.unix}"
   region = var.region
   project = var.project
   snapshot_schedule_policy {

--- a/gcp/secure_swarm_node/main.tf
+++ b/gcp/secure_swarm_node/main.tf
@@ -28,9 +28,7 @@ resource time_static self {
 resource time_static snapshot {
   triggers = {
     snapshot_properties = jsonencode(var.snapshot_properties)
-    daily_schedule = jsonencode(var.daily_schedule)
-    weekly_schedule = jsonencode(var.weekly_schedule)
-    hourly_schedule = jsonencode(var.hourly_schedule)
+    daily_schedule = jsonencode(var.data_disk_snapshot_schedule)
     retention_policy = jsonencode(var.retention_policy)
   }
 }
@@ -52,25 +50,25 @@ resource google_compute_resource_policy self {
   snapshot_schedule_policy {
     schedule{
       dynamic hourly_schedule {
-        for_each = var.hourly_schedule == null ? [] : [1]
+        for_each = var.data_disk_snapshot_schedule.frequency == "hourly" ? [1] : []
         content {
-          hours_in_cycle = var.hourly_schedule.hours_in_cycle
-          start_time = var.hourly_schedule.start_time
+          hours_in_cycle = var.data_disk_snapshot_schedule.interval
+          start_time = var.data_disk_snapshot_schedule.start_time
         }
       }
       dynamic daily_schedule {
         //If weekly or hourly schedule is specified ignore default daily schedule
-        for_each = var.weekly_schedule != null || var.hourly_schedule != null ? [] : [1]
+        for_each = var.data_disk_snapshot_schedule.frequency == "daily" ? [1] : []
         content {
-          days_in_cycle = var.daily_schedule.days_in_cycle
-          start_time = var.daily_schedule.start_time
+          days_in_cycle = var.data_disk_snapshot_schedule.interval
+          start_time = var.data_disk_snapshot_schedule.start_time
         }
       }
       dynamic weekly_schedule {
-        for_each = var.weekly_schedule == null ? [] : [1]
+        for_each = var.data_disk_snapshot_schedule.frequency == "weekly" ? [1] : []
         content {
           dynamic day_of_weeks{
-            for_each = var.weekly_schedule
+            for_each = var.data_disk_snapshot_schedule.weekly_snapshot_schedule
             content {
               day = day_of_weeks.value.day
               start_time = day_of_weeks.value.start_time

--- a/gcp/secure_swarm_node/main.tf
+++ b/gcp/secure_swarm_node/main.tf
@@ -24,6 +24,17 @@ resource time_static self {
   }
 }
 
+//Updates the google_compute_disk_resource_policy_attachment when google_compute_resource_policy is updated
+resource time_static snapshot {
+  triggers = {
+    snapshot_properties = jsonencode(var.snapshot_properties)
+    daily_schedule = jsonencode(var.daily_schedule)
+    weekly_schedule = jsonencode(var.weekly_schedule)
+    hourly_schedule = jsonencode(var.hourly_schedule)
+    retention_policy = jsonencode(var.retention_policy)
+  }
+}
+
 resource google_compute_disk self {
   provider  = google-beta
   name      = "${var.name}-${var.zone}-disk"
@@ -34,6 +45,64 @@ resource google_compute_disk self {
   interface = "NVME"
 }
 
+resource google_compute_resource_policy self {
+  name = "${var.name}-${var.zone}-${time_static.snapshot.unix}"
+  region = var.region
+  project = var.project
+  snapshot_schedule_policy {
+    schedule{
+      dynamic hourly_schedule {
+        for_each = var.hourly_schedule == null ? [] : [1]
+        content {
+          hours_in_cycle = var.hourly_schedule.hours_in_cycle
+          start_time = var.hourly_schedule.start_time
+        }
+      }
+      dynamic daily_schedule {
+        //If weekly or hourly schedule is specified ignore default daily schedule
+        for_each = var.weekly_schedule != null || var.hourly_schedule != null ? [] : [1]
+        content {
+          days_in_cycle = var.daily_schedule.days_in_cycle
+          start_time = var.daily_schedule.start_time
+        }
+      }
+      dynamic weekly_schedule {
+        for_each = var.weekly_schedule == null ? [] : [1]
+        content {
+          dynamic day_of_weeks{
+            for_each = var.weekly_schedule
+            content {
+              day = day_of_weeks.value.day
+              start_time = day_of_weeks.value.start_time
+            }
+          }
+        }
+      }
+    }
+    dynamic retention_policy {
+      for_each = var.retention_policy == null ? [] : [1]
+      content {
+        max_retention_days = var.retention_policy.max_retention_days
+        on_source_disk_delete = lookup(var.retention_policy, "on_source_disk_delete", null)
+      }
+    }
+    dynamic snapshot_properties {
+      for_each = var.snapshot_properties ==  null ? [] : [1]
+      content {
+        labels = lookup(var.snapshot_properties, "labels", null)
+        storage_locations =  lookup(var.snapshot_properties, "storage_locations", null)
+        guest_flush = lookup(var.snapshot_properties, "guest_flush", null)
+}
+    }
+  }
+}
+
+resource google_compute_disk_resource_policy_attachment self{
+  name = google_compute_resource_policy.self.name
+  disk = google_compute_disk.self.name
+  zone = "${var.region}-${var.zone}"
+  project = var.project
+}
 
 module secure_instance_template_blue {
   source      = "../compute_engine/instance_template"
@@ -114,8 +183,7 @@ resource google_compute_instance_group_manager self {
   version {
     name              = var.version_name == null ? formatdate("YYYYMMDDhhmm", time_static.self.rfc3339) : var.version_name
     instance_template = var.deployment_version == "blue" ? module.secure_instance_template_blue.self_link : module.secure_instance_template_green.self_link
-//    instance_template = module.secure_instance_template_blue.id
-  }
+}
 
   dynamic "auto_healing_policies" {
     for_each = [for health_check in var.health_check: {
@@ -154,4 +222,3 @@ resource google_compute_instance_group_manager self {
     }
   }
 }
-

--- a/gcp/secure_swarm_node/vars.tf
+++ b/gcp/secure_swarm_node/vars.tf
@@ -166,34 +166,28 @@ variable green_instance_template {
   default = {}
 }
 
-variable hourly_schedule {
-  description = "Hourly snapshot schedule"
+variable data_disk_snapshot_schedule {
+  description = "Hourly, Daily or Weekly snapshot schedule"
   type = object({
-    hours_in_cycle = number
-    start_time = string
+    frequency = string
+    start_time = optional(string)
+    interval = optional(number)
+    weekly_snapshot_schedule = optional(list(object({
+      day = string
+      start_time = string
+    })))
   })
-  default = null
-}
 
-variable daily_schedule {
-  description = "Daily snapshot schedule"
-  type = object({
-    days_in_cycle = number
-    start_time = string
-  })
   default = {
-    days_in_cycle = 1
-    start_time = "03:00"
+    frequency = "daily"
+    interval = 1
+    start_time = "3:00"
   }
-}
 
-variable weekly_schedule {
-  description = "Snapshot schedule for specified days of week."
-  type = list(object({
-    day = string
-    start_time = string
-  }))
-  default = null
+  validation {
+    condition = contains(["hourly", "daily", "weekly"], var.data_disk_snapshot_schedule.frequency)
+    error_message = "Frequency must be either 'hourly', 'daily', 'weekly'."
+  }
 }
 
 variable retention_policy {

--- a/gcp/secure_swarm_node/vars.tf
+++ b/gcp/secure_swarm_node/vars.tf
@@ -166,5 +166,51 @@ variable green_instance_template {
   default = {}
 }
 
+variable hourly_schedule {
+  description = "Hourly snapshot schedule"
+  type = object({
+    hours_in_cycle = number
+    start_time = string
+  })
+  default = null
+}
 
+variable daily_schedule {
+  description = "Daily snapshot schedule"
+  type = object({
+    days_in_cycle = number
+    start_time = string
+  })
+  default = {
+    days_in_cycle = 1
+    start_time = "03:00"
+  }
+}
 
+variable weekly_schedule {
+  description = "Snapshot schedule for specified days of week."
+  type = list(object({
+    day = string
+    start_time = string
+  }))
+  default = null
+}
+
+variable retention_policy {
+  description = "Retention Policy Applied to snapshots"
+  type = object({
+    max_retention_days = number
+    on_source_disk_delete = optional(string)
+  })
+  default = null
+}
+
+variable snapshot_properties {
+  type = object({
+    labels = optional(map(string))
+    storage_locations = optional(list(string))
+    guest_flush = optional(string)
+
+  })
+  default = null
+}


### PR DESCRIPTION
Attaches snapshot schedule to the persistent disk (defaults to daily at 3am). 
The `time_static.snapshot` resource listens for changes to snapshot configuration, and is used in the name of the `google_compute_resource_policy`. This is so `google_compute_resource_policy_attachment` updates on change to the snapshot configuration, as it references uses the `google_compute_resource_policy.name` attribute, and was not updating if the name did not change.
