### PR TITLE
Image family use and blue-green variables update

### DIFF
--- a/gcp/compute_engine/instance_template/main.tf
+++ b/gcp/compute_engine/instance_template/main.tf
@@ -23,11 +23,6 @@ data "google_compute_image" "image" {
   name    = var.source_image != "" ? var.source_image : "debian-10-buster-v20200714"
 }
 
-data "google_compute_image" "image_family" {
-  project = var.source_image_family != "" ? var.source_image_project : "debian-cloud"
-  family  = var.source_image_family != "" ? var.source_image_family : "debian-10"
-}
-
 data "google_compute_subnetwork" "subnet" {
   count = var.subnetwork == null ? 0: 1
   name   = var.subnetwork
@@ -41,7 +36,7 @@ data "google_compute_subnetwork" "subnet" {
 locals {
   boot_disk = [
     {
-      source_image = var.source_image != "" ? data.google_compute_image.image.self_link : data.google_compute_image.image_family.self_link
+      source_image = var.source_image != "" ? data.google_compute_image.image.self_link : "projects/${var.project_id}/global/images/family/${var.source_image_family}"
       disk_size_gb = var.disk_size_gb
       disk_type    = var.disk_type
       auto_delete  = var.auto_delete

--- a/gcp/secure_swarm_node/main.tf
+++ b/gcp/secure_swarm_node/main.tf
@@ -177,6 +177,7 @@ resource google_compute_instance_group_manager self {
   name               = "${var.name}-${var.zone}"
   zone               = "${var.region}-${var.zone}"
   project            = var.project
+  wait_for_instances = true
   wait_for_instances_status = "STABLE"
   target_size        = var.target_size
 

--- a/gcp/secure_swarm_node/main.tf
+++ b/gcp/secure_swarm_node/main.tf
@@ -108,7 +108,7 @@ module secure_instance_template_blue {
   description = "Secure Swarm zone template"
   service_account = {
     email  = local.service_account_email
-    scopes = var.service_account_scopes
+    scopes = var.blue_instance_template.service_account_scopes == null ? var.service_account_scopes : var.blue_instance_template.service_account_scopes
   }
   region               = var.region
   zone                 = var.zone
@@ -121,6 +121,7 @@ module secure_instance_template_blue {
   subnetwork_project   = var.blue_instance_template.subnetwork == null ? null : var.project
   network              = var.blue_instance_template.network == null ? var.network : var.blue_instance_template.network
   subnetwork           = var.blue_instance_template.subnetwork == null ? var.subnetwork : var.blue_instance_template.subnetwork
+  network_ip           = var.blue_instance_template.network_ip == null ? var.network_ip : var.blue_instance_template.network_ip
   access_config        = var.blue_instance_template.access_config == null ?  var.access_config: var.blue_instance_template.access_config
   on_host_maintenance  = local.blue_instance_template["security_level"]  == "confidential-1" ? "TERMINATE" : "MIGRATE"
   additional_disks = [{
@@ -133,7 +134,6 @@ module secure_instance_template_blue {
     mode         = "READ_WRITE"
   }]
   security_level = local.blue_instance_template["security_level"]
-  network_ip = var.network_ip
 }
 
 
@@ -143,7 +143,7 @@ module secure_instance_template_green {
   description = "Secure Swarm zone template"
   service_account = {
     email  = local.service_account_email
-    scopes = var.service_account_scopes
+    scopes = var.green_instance_template.service_account_scopes == null ? var.service_account_scopes : var.green_instance_template.service_account_scopes
   }
   region               = var.region
   zone                 = var.zone
@@ -154,8 +154,9 @@ module secure_instance_template_green {
   source_image_family  = var.green_instance_template.source_image_family == null ?  var.source_image_family : var.green_instance_template.source_image_family
   source_image_project = var.green_instance_template.source_image_project == null ? var.source_image_project : var.green_instance_template.source_image_project
   subnetwork_project   = var.green_instance_template.subnetwork == null ? null : var.project
-  network              = var.green_instance_template.network == null? var.network : var.green_instance_template.network
+  network              = var.green_instance_template.network == null ? var.network : var.green_instance_template.network
   subnetwork           = var.green_instance_template.subnetwork == null? var.subnetwork : var.green_instance_template.subnetwork
+  network_ip           = var.green_instance_template.network_ip == null ? var.network_ip : var.green_instance_template.network_ip
   access_config        = var.green_instance_template.access_config == null?  var.access_config: var.green_instance_template.access_config
   on_host_maintenance  = local.green_instance_template["security_level"]  == "confidential-1" ? "TERMINATE" : "MIGRATE"
   additional_disks = [{
@@ -168,7 +169,6 @@ module secure_instance_template_green {
     mode         = "READ_WRITE"
   }]
   security_level = local.green_instance_template["security_level"]
-  network_ip = var.network_ip
 }
 
 resource google_compute_instance_group_manager self {

--- a/gcp/secure_swarm_node/vars.tf
+++ b/gcp/secure_swarm_node/vars.tf
@@ -146,8 +146,10 @@ variable blue_instance_template {
     source_image_project = optional(string)
     network = optional(string)
     subnetwork = optional(string)
+    network_ip = optional(string)
     access_config = optional(map(list(map(string))))
     security_level = optional(string)
+    service_account_scopes = optional(set(string))
   })
   default = {}
 }
@@ -160,8 +162,10 @@ variable green_instance_template {
     source_image_project = optional(string)
     network = optional(string)
     subnetwork = optional(string)
+    network_ip = optional(string)
     access_config = optional(map(list(map(string))))
     security_level = optional(string)
+    service_account_scopes = optional(set(string))
   })
   default = {}
 }


### PR DESCRIPTION
* Updated the `source_image` option to use `"projects/{project}/global/images/family/{family}"`
* Add `wait_for_instance=true`
* Add `network_ip` and `service_account_scopes` to `blue/green_instance_template` so all instance template attributes can be configured with blue green methods