### PR TITLE
Bug/pk2 m 147/secure swarm persistent disk

### DIFF
--- a/gcp/compute_engine/instance_template/main.tf
+++ b/gcp/compute_engine/instance_template/main.tf
@@ -40,6 +40,7 @@ locals {
       disk_size_gb = var.disk_size_gb
       disk_type    = var.disk_type
       auto_delete  = var.auto_delete
+      interface    = var.disk_interface
       boot         = "true"
     },
   ]
@@ -108,10 +109,6 @@ resource google_compute_instance_template self {
         network_tier = lookup(access_config.value, "network_tier", null)
       }
     }
-  }
-
-  lifecycle {
-    create_before_destroy = "true"
   }
 
   # scheduling must have automatic_restart be false when preemptible is true.

--- a/gcp/compute_engine/instance_template/main.tf
+++ b/gcp/compute_engine/instance_template/main.tf
@@ -145,4 +145,8 @@ resource google_compute_instance_template self {
       type  = ""
     }
   }
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }

--- a/gcp/compute_engine/instance_template/vars.tf
+++ b/gcp/compute_engine/instance_template/vars.tf
@@ -106,7 +106,7 @@ variable "source_image_project" {
 variable "disk_size_gb" {
   description = "Boot disk size in GB"
   type = number
-  default = 100
+  default = 10
 }
 
 variable "disk_type" {

--- a/gcp/compute_engine/instance_template/vars.tf
+++ b/gcp/compute_engine/instance_template/vars.tf
@@ -40,7 +40,8 @@ variable "machine_type" {
 
 variable "can_ip_forward" {
   description = "Enable IP forwarding, for NAT instances for example"
-  default     = "false"
+  type = bool
+  default     = false
 }
 
 variable "tags" {
@@ -86,32 +87,43 @@ variable "region" {
 #######
 variable "source_image" {
   description = "Source disk image. If neither source_image nor source_image_family is specified, defaults to the latest public Debian image."
+  type = string
   default     = ""
 }
 
 variable "source_image_family" {
   description = "Source image family. If neither source_image nor source_image_family is specified, defaults to the latest public Debian image."
+  type = string
   default     = "debian-10"
 }
 
 variable "source_image_project" {
   description = "Project where the source image comes from. The default project contains images that support Shielded VMs if desired"
+  type = string
   default     = "debian-cloud"
 }
 
 variable "disk_size_gb" {
   description = "Boot disk size in GB"
-  default     = "100"
+  type = number
+  default = 100
 }
 
 variable "disk_type" {
   description = "Boot disk type, can be either pd-ssd, local-ssd, or pd-standard"
+  type = string
   default     = "pd-standard"
+}
+
+variable "disk_interface" {
+  description = "Interface for the boot disk. Eiter SCSI (default) or NVME (confidential compute)"
+  type = string
+  default = "SCSI"
 }
 
 variable "auto_delete" {
   description = "Whether or not the boot disk should be auto-deleted"
-  default     = "true"
+  default     = true
 }
 
 variable "additional_disks" {
@@ -123,6 +135,7 @@ variable "additional_disks" {
     disk_name    = string
     disk_size_gb = number
     disk_type    = string
+    interface    = string
   }))
   default = []
 }

--- a/gcp/secure_swarm_node/main.tf
+++ b/gcp/secure_swarm_node/main.tf
@@ -33,13 +33,23 @@ resource time_static resource_policy_time {
   }
 }
 
+resource time_static disk_creation_time {
+  triggers = {
+    disk_size = var.disk_size
+    disk_type = var.disk_type
+  }
+}
+
 resource google_compute_disk self {
   provider  = google-beta
-  name      = "${var.name}-${var.zone}-data"
+  name      = "${var.name}-${var.zone}-data-${formatdate("YYYYMMDDhhmm", time_static.disk_creation_time.rfc3339)}"
   zone      = "${var.region}-${var.zone}"
   project   = var.project
   labels    = var.labels
   size      = var.disk_size
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource google_compute_resource_policy self {
@@ -130,7 +140,7 @@ module secure_instance_template_blue {
     device_name  = google_compute_disk.self.name
     disk_name    = google_compute_disk.self.name
     disk_size_gb = var.disk_size
-    disk_type    = "pd-standard"
+    disk_type    = var.disk_type
     mode         = "READ_WRITE"
     interface    = "NVME"
   }]
@@ -167,7 +177,7 @@ module secure_instance_template_green {
     device_name  = google_compute_disk.self.name
     disk_name    = google_compute_disk.self.name
     disk_size_gb = var.disk_size
-    disk_type    = "pd-standard"
+    disk_type    = var.disk_type
     mode         = "READ_WRITE"
     interface    = "NVME"
   }]

--- a/gcp/secure_swarm_node/main.tf
+++ b/gcp/secure_swarm_node/main.tf
@@ -40,7 +40,6 @@ resource google_compute_disk self {
   project   = var.project
   labels    = var.labels
   size      = var.disk_size
-  interface = "NVME"
 }
 
 resource google_compute_resource_policy self {
@@ -124,6 +123,7 @@ module secure_instance_template_blue {
   network_ip           = var.blue_instance_template.network_ip == null ? var.network_ip : var.blue_instance_template.network_ip[var.zone]
   access_config        = var.blue_instance_template.access_config == null ?  var.access_config: var.blue_instance_template.access_config
   on_host_maintenance  = local.blue_instance_template["security_level"]  == "confidential-1" ? "TERMINATE" : "MIGRATE"
+  disk_interface = "NVME"
   additional_disks = [{
     boot         = false
     auto_delete  = false
@@ -132,6 +132,7 @@ module secure_instance_template_blue {
     disk_size_gb = var.disk_size
     disk_type    = "pd-standard"
     mode         = "READ_WRITE"
+    interface    = "NVME"
   }]
   security_level = local.blue_instance_template["security_level"]
 }
@@ -159,6 +160,7 @@ module secure_instance_template_green {
   network_ip           = var.green_instance_template.network_ip == null ? var.network_ip : var.green_instance_template.network_ip[var.zone]
   access_config        = var.green_instance_template.access_config == null?  var.access_config: var.green_instance_template.access_config
   on_host_maintenance  = local.green_instance_template["security_level"]  == "confidential-1" ? "TERMINATE" : "MIGRATE"
+  disk_interface = "NVME"
   additional_disks = [{
     boot         = false
     auto_delete  = false
@@ -167,6 +169,7 @@ module secure_instance_template_green {
     disk_size_gb = var.disk_size
     disk_type    = "pd-standard"
     mode         = "READ_WRITE"
+    interface    = "NVME"
   }]
   security_level = local.green_instance_template["security_level"]
 }

--- a/gcp/secure_swarm_node/vars.tf
+++ b/gcp/secure_swarm_node/vars.tf
@@ -29,6 +29,12 @@ variable "disk_size" {
   default = 500
 }
 
+variable "disk_type" {
+  description = "Type of disk to attach to instance, default is standard persistent disk"
+  type    = string
+  default = "pd-standard"
+}
+
 variable "access_config" {
   type = map(list(map(string)))
   default = {}


### PR DESCRIPTION
* Removed `interface` from `google_compute_disk` due to [issue](https://github.com/hashicorp/terraform-provider-google/issues/10006) with setting interface to NVME
* Updated disk name to depend on `time_static` resource that is triggered by updates to the disk size or type. Changed lifecycle back to create_before_destroy, so it will create a new disk of a different name before attempting delete the disk (which will be attached to an instance). 
If update policy isn't in place the error with detaching NVME disk will still occur, but with update policy set to recreate, the instance group manager will handle the recreation of instances with the new disk