### PR TITLE
Fix Cloud SDK install step for github actions

### DIFF
--- a/.github/workflows/deployment_tests.yml
+++ b/.github/workflows/deployment_tests.yml
@@ -15,7 +15,6 @@ jobs:
       working-directory: ./tests/mcp/deployment
       GCP_PROJECT_ID: "mcpdeploytest-${GITHUB_SHA::8}-$(date +%H%M%S)"
       KUBE_CONFIG_PATH: ~/.kube/config
-      CLOUDSDK_PYTHON: python
 
     defaults:
       run:
@@ -27,18 +26,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
-
       # Install the latest version of Terraform CLI
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
         with:
           terraform_wrapper: false
 
-      # Install gcoud sdk and set the service account
+      # Install gcloud sdk and set the service account
       - name: Setup Cloud SDK
         uses: google-github-actions/setup-gcloud@master
         with:
@@ -167,7 +161,6 @@ jobs:
     env:
       working-directory: ./tests/gcp/deployment
       NEW_PROJECT_ID: "test-vpc-${GITHUB_SHA::8}-$(date +%H%M%S)"
-      CLOUDSDK_PYTHON: python
 
     defaults:
       run:
@@ -189,11 +182,6 @@ jobs:
         with:
           service_account_key: ${{secrets.GCP_VPC_SA_KEY}}
           export_default_credentials: true
-
-      - name: Install Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
 
       - name: Validate Yaml
         run: |

--- a/.github/workflows/deployment_tests.yml
+++ b/.github/workflows/deployment_tests.yml
@@ -15,7 +15,7 @@ jobs:
       working-directory: ./tests/mcp/deployment
       GCP_PROJECT_ID: "mcpdeploytest-${GITHUB_SHA::8}-$(date +%H%M%S)"
       KUBE_CONFIG_PATH: ~/.kube/config
-      CLOUDSDK_PYTHON: python3.10
+      CLOUDSDK_PYTHON: python
 
     defaults:
       run:
@@ -167,7 +167,7 @@ jobs:
     env:
       working-directory: ./tests/gcp/deployment
       NEW_PROJECT_ID: "test-vpc-${GITHUB_SHA::8}-$(date +%H%M%S)"
-      CLOUDSDK_PYTHON: python3.10
+      CLOUDSDK_PYTHON: python
 
     defaults:
       run:

--- a/.github/workflows/deployment_tests.yml
+++ b/.github/workflows/deployment_tests.yml
@@ -15,6 +15,7 @@ jobs:
       working-directory: ./tests/mcp/deployment
       GCP_PROJECT_ID: "mcpdeploytest-${GITHUB_SHA::8}-$(date +%H%M%S)"
       KUBE_CONFIG_PATH: ~/.kube/config
+      CLOUDSDK_PYTHON: python3.10
 
     defaults:
       run:
@@ -166,6 +167,7 @@ jobs:
     env:
       working-directory: ./tests/gcp/deployment
       NEW_PROJECT_ID: "test-vpc-${GITHUB_SHA::8}-$(date +%H%M%S)"
+      CLOUDSDK_PYTHON: python3.10
 
     defaults:
       run:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,7 +19,6 @@ jobs:
     if: ${{github.event.pull_requests.labels.*.name == 'feature'}} || ${{github.event.pull_requests.labels.*.name == 'bug'}} || ${{github.event.pull_requests.labels.*.name == 'patch'}}
     env:
       working-directory: ./tests/
-      CLOUDSDK_PYTHON: python
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:
       run:
@@ -30,12 +29,6 @@ jobs:
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
       uses: actions/checkout@v2
-      
-    # Install Python
-    - name: Install Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
 
     # Install the latest version of Terraform CLI
     - name: Setup Terraform

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,7 +19,7 @@ jobs:
     if: ${{github.event.pull_requests.labels.*.name == 'feature'}} || ${{github.event.pull_requests.labels.*.name == 'bug'}} || ${{github.event.pull_requests.labels.*.name == 'patch'}}
     env:
       working-directory: ./tests/
-      CLOUDSDK_PYTHON: python3.10
+      CLOUDSDK_PYTHON: python
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:
       run:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - main
       - develop
-      - bug/ps-45/cloudsdk_step_fix
     types: [opened, synchronize, reopened, labeled]
   push:
     branches:
       - main
       - develop
+      - bug/ps-45/cloudsdk_step_fix
 
 jobs:
   unit-tests:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - develop
+      - bug/ps-45/cloudsdk_step_fix
     types: [opened, synchronize, reopened, labeled]
   push:
     branches:
@@ -18,6 +19,7 @@ jobs:
     if: ${{github.event.pull_requests.labels.*.name == 'feature'}} || ${{github.event.pull_requests.labels.*.name == 'bug'}} || ${{github.event.pull_requests.labels.*.name == 'patch'}}
     env:
       working-directory: ./tests/
+      CLOUDSDK_PYTHON: python3.10
     # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
     defaults:
       run:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -10,7 +10,6 @@ on:
     branches:
       - main
       - develop
-      - bug/ps-45/cloudsdk_step_fix
 
 jobs:
   unit-tests:


### PR DESCRIPTION
Removed the python install step to avoid conflicts with the cloud sdk step. Python v3.8 is installed by default, as we don't provide any custom configuration for python, the step for install is no longer required