### PR TITLE
Fix issue with MIG disk attachment

### DIFF
--- a/gcp/compute_engine/instance_template/main.tf
+++ b/gcp/compute_engine/instance_template/main.tf
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+terraform {
+  experiments = [module_variable_optional_attrs]
+}
 
 ###############
 # Data Sources
@@ -79,7 +82,8 @@ resource google_compute_instance_template self {
       source       = lookup(disk.value, "source", null)
       source_image = lookup(disk.value, "source_image", null)
       type         = lookup(disk.value, "type", null)
-
+      labels       = lookup(disk.value, "labels", null )
+      resource_policies = lookup(disk.value, "resource_policies", null)
       dynamic "disk_encryption_key" {
         for_each = lookup(disk.value, "disk_encryption_key", [])
         content {

--- a/gcp/compute_engine/instance_template/main.tf
+++ b/gcp/compute_engine/instance_template/main.tf
@@ -45,6 +45,8 @@ locals {
       auto_delete  = var.auto_delete
       interface    = var.disk_interface
       boot         = "true"
+      device_name  = var.boot_device_name
+      mode         = "READ_WRITE"
     },
   ]
 

--- a/gcp/compute_engine/instance_template/vars.tf
+++ b/gcp/compute_engine/instance_template/vars.tf
@@ -131,11 +131,17 @@ variable "additional_disks" {
   type = list(object({
     auto_delete  = bool
     boot         = bool
-    device_name  = string
-    disk_name    = string
-    disk_size_gb = number
-    disk_type    = string
-    interface    = string
+    device_name  = optional(string)
+    disk_name    = optional(string)
+    disk_size_gb = optional(number)
+    disk_type    = optional(string)
+    interface    = optional(string)
+    mode         = optional(string)
+    source       = optional(string)
+    source_image = optional(string)
+    type         = optional(string)
+    labels       = optional(map(string))
+    resource_policies = optional(list(string))
   }))
   default = []
 }

--- a/gcp/compute_engine/instance_template/vars.tf
+++ b/gcp/compute_engine/instance_template/vars.tf
@@ -85,6 +85,12 @@ variable "region" {
 #######
 # disk
 #######
+variable "boot_device_name" {
+  description = "Device name for the boot disk"
+  type = string
+  default     = null
+}
+
 variable "source_image" {
   description = "Source disk image. If neither source_image nor source_image_family is specified, defaults to the latest public Debian image."
   type = string

--- a/gcp/secure_swarm_node/README.md
+++ b/gcp/secure_swarm_node/README.md
@@ -1,9 +1,22 @@
 # Secure Swarm Node
+### Contents
+1. [Information](#information)
+2. [Resources](#resources)
+3. [Blue Green Deployment](#blue-green-deployment)
+4. [Example Usage](#example-usage)
+5. [Troubleshooting](#troubleshooting)
 
-This module deploys a Secure Swarm Node with Shielded instance configuration enabled 
-and optionally confidential computing enabled.
 
-Required Variables for the module are:
+##  Information
+This module deploys a Managed Instance Group (MIG), which creates instances with Shielded Instance Configuration enabled 
+and optionally [confidential computing](https://cloud.google.com/compute/confidential-vm/docs/about-cvm) enabled, 
+to be used as a secure docker swarm node.
+
+### Prerequisites
+* GCP project with Compute Engine API enabled
+* Billing account for project
+
+### Required variables
 * `project` - GCP project ID
 * `deployment_version` - `"blue"` or `"green"` representing the `instance_template` version the `instance_group_manager` will use for the deploymetn
 * `zone` - The zone the compute instances will be deployed in
@@ -12,22 +25,54 @@ Required Variables for the module are:
   * `"confidential-1` - Same settings as `"secure-1"` but with confidential computing enabled as well
 
 ## Resources
-### Compute Disks
-Compute disks are configured with NVME interface with the name being <name>-<zone>-disk. These are configured with a snapshot schedule, which defaults to being done daily at 3am 
-(see [Terraform Documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_resource_policy) for more details).
 
 ### Instance Templates
-The instance templates are used for configuring the secure and confidential VMs. The name prefix will be <name>-<zone>-<blue/green>- and will be assigned a version, by the managed instance group, which is either the date-time, or a custom version name.
+The instance templates are used by the Instance Group Manager to deploy the specified secure/confidential VMs. 
+The name prefix will be `${var.name}-${var.zone}-${var.deployment_version}-` and will be assigned a version on deployment.
+
+The template defines:
+* Compute instance shielded/confidential configuration
+* Source image for boot disk
+* Persistent disk config
+  * Disk `interface` is set to `NVME` if using confidential computing, otherwise it is `SCSI`
+  * This disk **will NOT be deleted** on terraform destroy, as is created outside terraform. 
+    Persistent disk removal must be done manually.
+* Network configuration
+  * VPC network to use
+  * Optional network IP and external IP to use
+
 
 ### Managed Instance Group
-The instance group has the name <name>-<zone> and configures the ports, stateful disk, update policy and auto healing policies for the VM.  
+The instance group has the name `${var.name}-${var.zone}` and configures the ports, stateful disk, update policy and auto healing policies for the VM.  
 If using the timestamp for the configuration, the version of the instance will update when there is a change to:
 * Deployment version (blue or green)
 * The fingerprint of the instance template corresponding to the deployment version
 * Update Policy
 * Health Check
 * Named Ports  
-Otherwise it will update when var.version is updated.
+
+Otherwise, it will update when `${var.version}` is updated.
+
+#### Confidential Compute Instance configuration
+To use auto healing in the MIG with confidential compute instances, the boot disk must be set as stateful (see [troubleshooting](#troubleshooting)).  
+If `stateful_disk_delete_rule` is set to `NEVER`, the boot disk will persist after deletion of the instance it was attached to. 
+If it is set to `ON_PERMANENT_INSTANCE_DELETION`:
+* Boot disk **persists** and is reattached to instance when:
+  * Auto healing recreates instance after health check fail
+  * Instance is stopped using `gcloud compute instances stop`
+  * instance is deleted using `gcould compute insattnces delete`
+* Boot disk is **deleted** when
+  * instance group manager `target_size = 0` and `terraform apply` is done. 
+
+If updating the `source_image` in the instance template, the image will not be updated on the instance in any of the above scenarios where the disk persists. 
+To update the image on instances:
+1. Set `target_size = 0`
+2. Run `terraform apply` and wait for instance group to finish updating
+3. Set `target_size = 1`
+4. Run `terraform apply` again, and the instance will be recreated with new image on disk
+
+**NOTE:** If instance is a swarm node, it will rejoin the swarm in any of the instances where the boot disk persists. 
+But, if not configured to on the image in use, will not rejoin after boot disk is deleted.
 
 ## Blue-Green Deployment
 The instance templates are deployed using a blue-green deployment approach.
@@ -101,26 +146,16 @@ module "secure_swarm_b" {
 }
 ```
 
-
-
-Disk Snapshot schedule configuration takes one of the following fomats:
-```hcl
-data_disk_snapshot_schedule = {
-  frequency = "hourly" | "daily"
-  interval = number
-  start_time = time
-} 
-
----------or----------
-
-data_disk_snapshot_schedule = {
-  frequency = "weekly"
-  weekly_snapshot_schedule = [
-    {
-      day = "MONDAY" | "TUESDAY" | ... | "SUNDAY"
-      start_time = time
-    },
-    ...
-  ]
-}
-```
+## Troubleshooting
+### Instance update failed: NVME interface must be specified when the disk is created rather than during attachment
+ 
+Likely scenarios this occurs in:
+* Instance template configured with existing persistent disk, which did not have `interface` set to `NVME` on creation. 
+  * Use an existing disk that was created with `NVME` interface specified
+  * Use disk created with this module in the [instance template](#instance-templates) configuration
+* During autohealing by MIG, if not set as stateful, the boot disk will be recreated as `${boot-disk-name}-temp`. 
+  That disk has an interface of `SCSI` regardless of the interface configuration in the used instance template. 
+  This instance will be recreated, but unable to join the instance group, so recreation will be indefinite until either:
+  * MIG is scaled down to 0 instance, then scaled back up to 1 to create a completely new instance and boot disk from the specified template
+  * Set `stateful_boot` to `true` to have persistence on the boot disk (see [config documention](#confidential-compute-instance-configuration)),
+    meaning the interfacce is never changed from `NVME`, allowing recreated instance to rejoin the instance group

--- a/gcp/secure_swarm_node/locals.tf
+++ b/gcp/secure_swarm_node/locals.tf
@@ -6,5 +6,13 @@ locals {
   green_instance_template = lookup(var.green_instance_template, "security_level", null) == null ? merge(
     var.green_instance_template, { security_level = var.security_level }
   ) : contains(["secure-1", "confidential-1"], var.green_instance_template["security_level"]) ? var.green_instance_template : merge(var.green_instance_template, { security_level = "confidential-1" })
+
+  stateful_boot_disk = var.stateful_boot ? [{
+    device_name = "${var.name}-${var.zone}-boot"
+    delete_rule = var.stateful_boot_delete_rule
+  }] : []
+
+  service_account_email = var.service_account_email == "" ? "${data.google_project.default.number}@-compute@developer.gserviceaccount.com" : var.service_account_email
+
 }
 

--- a/gcp/secure_swarm_node/locals.tf
+++ b/gcp/secure_swarm_node/locals.tf
@@ -11,8 +11,5 @@ locals {
     device_name = "${var.name}-${var.zone}-boot"
     delete_rule = var.stateful_boot_delete_rule
   }] : []
-
-  service_account_email = var.service_account_email == "" ? "${data.google_project.default.number}@-compute@developer.gserviceaccount.com" : var.service_account_email
-
 }
 

--- a/gcp/secure_swarm_node/main.tf
+++ b/gcp/secure_swarm_node/main.tf
@@ -1,3 +1,8 @@
+//Keep this local variable here, as moving it to locals.tf breaks unit tests
+locals {
+  service_account_email = var.service_account_email == "" ? "${data.google_project.default.number}@-compute@developer.gserviceaccount.com" : var.service_account_email
+}
+
 data google_project default {
   project_id = var.project
 }

--- a/gcp/secure_swarm_node/main.tf
+++ b/gcp/secure_swarm_node/main.tf
@@ -1,9 +1,3 @@
-terraform {
-  required_version = ">= 0.14.0"
-  experiments = [module_variable_optional_attrs]
-}
-
-
 data google_project default {
   project_id = var.project
 }
@@ -14,10 +8,6 @@ data google_compute_health_check self {
   project  = var.project
 }
 
-locals {
-  service_account_email = var.service_account_email == "" ? "${data.google_project.default.number}@-compute@developer.gserviceaccount.com" : var.service_account_email
-}
-
 //Updates the time for the version when the template is updated or certain properties of MIG are updated
 resource time_static self {
   triggers = {
@@ -26,67 +16,6 @@ resource time_static self {
     update_policy = jsonencode(var.update_policy)
     health_check = jsonencode(var.health_check)
     named_ports = jsonencode(var.named_ports)
-  }
-}
-
-//Updates the google_compute_disk_resource_policy_attachment when google_compute_resource_policy is updated
-resource time_static resource_policy_time {
-  triggers = {
-    snapshot_properties = jsonencode(var.snapshot_properties)
-    data_disk_snapshot_schedule = jsonencode(var.data_disk_snapshot_schedule)
-    retention_policy = jsonencode(var.retention_policy)
-  }
-}
-
-resource google_compute_resource_policy self {
-  name = "${var.name}-${var.zone}-${time_static.resource_policy_time.unix}"
-  region = var.region
-  project = var.project
-  snapshot_schedule_policy {
-    schedule{
-      dynamic hourly_schedule {
-        for_each = var.data_disk_snapshot_schedule.frequency == "hourly" ? [1] : []
-        content {
-          hours_in_cycle = var.data_disk_snapshot_schedule.interval
-          start_time = var.data_disk_snapshot_schedule.start_time
-        }
-      }
-      dynamic daily_schedule {
-        //If weekly or hourly schedule is specified ignore default daily schedule
-        for_each = var.data_disk_snapshot_schedule.frequency == "daily" ? [1] : []
-        content {
-          days_in_cycle = var.data_disk_snapshot_schedule.interval
-          start_time = var.data_disk_snapshot_schedule.start_time
-        }
-      }
-      dynamic weekly_schedule {
-        for_each = var.data_disk_snapshot_schedule.frequency == "weekly" ? [1] : []
-        content {
-          dynamic day_of_weeks{
-            for_each = var.data_disk_snapshot_schedule.weekly_snapshot_schedule
-            content {
-              day = day_of_weeks.value.day
-              start_time = day_of_weeks.value.start_time
-            }
-          }
-        }
-      }
-    }
-    dynamic retention_policy {
-      for_each = var.retention_policy == null ? [] : [1]
-      content {
-        max_retention_days = var.retention_policy.max_retention_days
-        on_source_disk_delete = lookup(var.retention_policy, "on_source_disk_delete", null)
-      }
-    }
-    dynamic snapshot_properties {
-      for_each = var.snapshot_properties ==  null ? [] : [1]
-      content {
-        labels = lookup(var.snapshot_properties, "labels", null)
-        storage_locations =  lookup(var.snapshot_properties, "storage_locations", null)
-        guest_flush = lookup(var.snapshot_properties, "guest_flush", null)
-}
-    }
   }
 }
 
@@ -112,8 +41,9 @@ module secure_instance_template_blue {
   network_ip           = var.blue_instance_template.network_ip == null ? var.network_ip : var.blue_instance_template.network_ip[var.zone]
   access_config        = var.blue_instance_template.access_config == null ?  var.access_config: var.blue_instance_template.access_config
   on_host_maintenance  = local.blue_instance_template["security_level"]  == "confidential-1" ? "TERMINATE" : "MIGRATE"
-    disk_interface = var.security_level == "confidential-1" ? "NVME" : "SCSI"
-  additional_disks = [{
+  disk_interface       = var.security_level == "confidential-1" ? "NVME" : "SCSI"
+  auto_delete          = !var.stateful_boot
+  additional_disks     = [{
     boot         = false
     auto_delete  = false
     device_name  = "${var.name}-${var.zone}-data"
@@ -122,10 +52,12 @@ module secure_instance_template_blue {
     disk_type    = var.disk_type
     mode         = "READ_WRITE"
     interface    = var.security_level == "confidential-1" ? "NVME" : "SCSI"
-    resource_policies = [google_compute_resource_policy.self.id]
+    resource_policies = var.disk_resource_policies
   }]
   security_level = local.blue_instance_template["security_level"]
-  tags = var.tags
+  tags           = var.tags
+  metadata       = var.metadata
+
 }
 
 
@@ -151,7 +83,9 @@ module secure_instance_template_green {
   network_ip           = var.green_instance_template.network_ip == null ? var.network_ip : var.green_instance_template.network_ip[var.zone]
   access_config        = var.green_instance_template.access_config == null?  var.access_config: var.green_instance_template.access_config
   on_host_maintenance  = local.green_instance_template["security_level"]  == "confidential-1" ? "TERMINATE" : "MIGRATE"
-  disk_interface = var.security_level == "confidential-1" ? "NVME" : "SCSI"
+  disk_interface       = var.security_level == "confidential-1" ? "NVME" : "SCSI"
+  auto_delete          = !var.stateful_boot
+  boot_device_name     = "${var.name}-${var.zone}-boot"
   additional_disks = [{
     boot         = false
     auto_delete  = false
@@ -161,10 +95,11 @@ module secure_instance_template_green {
     disk_type    = var.disk_type
     mode         = "READ_WRITE"
     interface    = var.security_level == "confidential-1" ? "NVME" : "SCSI"
-    resource_policies = [google_compute_resource_policy.self.id]
+    resource_policies = var.disk_resource_policies
   }]
   security_level = local.green_instance_template["security_level"]
-  tags = var.tags
+  tags           = var.tags
+  metadata       = var.metadata
 }
 
 resource google_compute_instance_group_manager self {
@@ -196,6 +131,16 @@ resource google_compute_instance_group_manager self {
   stateful_disk {
     device_name = "${var.name}-${var.zone}-data"
     delete_rule = "NEVER"
+  }
+
+  # For optional stateful boot disk
+  dynamic "stateful_disk" {
+    for_each = local.stateful_boot_disk
+    //noinspection HILUnresolvedReference
+    content {
+      device_name = stateful_disk.value.device_name
+      delete_rule = stateful_disk.value.delete_rule
+    }
   }
 
   dynamic "update_policy" {

--- a/gcp/secure_swarm_node/main.tf
+++ b/gcp/secure_swarm_node/main.tf
@@ -125,6 +125,7 @@ module secure_instance_template_blue {
     resource_policies = [google_compute_resource_policy.self.id]
   }]
   security_level = local.blue_instance_template["security_level"]
+  tags = var.tags
 }
 
 
@@ -163,6 +164,7 @@ module secure_instance_template_green {
     resource_policies = [google_compute_resource_policy.self.id]
   }]
   security_level = local.green_instance_template["security_level"]
+  tags = var.tags
 }
 
 resource google_compute_instance_group_manager self {

--- a/gcp/secure_swarm_node/providers.tf
+++ b/gcp/secure_swarm_node/providers.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.14.0, < 2.0.0"
+  experiments = [module_variable_optional_attrs]
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+      version = "~> 4.1.0"
+    }
+  }
+}

--- a/gcp/secure_swarm_node/vars.tf
+++ b/gcp/secure_swarm_node/vars.tf
@@ -22,6 +22,11 @@ variable "labels" {
   default = null
 }
 
+variable "tags" {
+  type = list(string)
+  description = "Tags for instance template"
+  default = []
+}
 
 //Disk configuration
 variable "disk_size" {

--- a/tests/gcp/unit_tests/secure_swarm_node/vars.tf
+++ b/tests/gcp/unit_tests/secure_swarm_node/vars.tf
@@ -11,3 +11,19 @@ variable "green_instance_template" {
 variable "security_level" {
   default = "secure-2"
 }
+
+variable "stateful_boot" {
+  default = false
+}
+
+variable "stateful_boot_delete_rule" {
+  default = "NEVER"
+}
+
+variable "name" {
+  default = "unit-test"
+}
+
+variable "zone" {
+  default = "a"
+}


### PR DESCRIPTION
* Removed persistent disk resource, so created via instance template, and therefore no longer managed by terraform
* Added option for stateful boot disk, to avoid issue with MIG autohealing recreating disk with `SCSI` interface for confidential vms
* Removed`google_compute_resource_policy` and `google_compute_disk_resource_policy_attachment`. Can still optionally add existing resource policy to disk configuration using `disk_resource_policies` variable.
* Updated documentation
* Added version constraints for google provider, and `terraform{}` block to `providers.tf` 