### PR TITLE
Optional persistent disk

### DIFF
--- a/gcp/secure_swarm_node/README.md
+++ b/gcp/secure_swarm_node/README.md
@@ -173,12 +173,13 @@ Mount the disk in desired folder e.g. at `/data`:
 ```shell
 sudo mount -o discard,defaults /dev/nvme02 /data
 ```
-To mount the disk on automatically on restart, edit the `/etc/fstab` file to include one the line (uncomment relevant one):
+To mount the disk on automatically on restart, edit the `/etc/fstab` file to include one of the following lines:
 ```shell
-#Confidential VM
-#/dev/nvme0n2 /data 	ext4	defaults	0 0
-#Shielded VM
-#/dev/sdb /data 	ext4	defaults	0 0
+# Confidential VM
+/dev/nvme0n2 /data 	ext4	defaults	0 0
+
+# or Shielded VM
+/dev/sdb  /data 	ext4	defaults	0 0
 ```
 ### 2.Install  and configure docker
 ## Troubleshooting

--- a/gcp/secure_swarm_node/main.tf
+++ b/gcp/secure_swarm_node/main.tf
@@ -49,7 +49,7 @@ module secure_instance_template_blue {
   disk_size_gb         = var.boot_disk_size
   disk_interface       = var.security_level == "confidential-1" ? "NVME" : "SCSI"
   auto_delete          = !var.stateful_boot
-  additional_disks     = [{
+  additional_disks     = var.persistent_disk ? [{
     boot         = false
     auto_delete  = false
     device_name  = "${var.name}-${var.zone}-data"
@@ -59,7 +59,7 @@ module secure_instance_template_blue {
     mode         = "READ_WRITE"
     interface    = var.security_level == "confidential-1" ? "NVME" : "SCSI"
     resource_policies = var.disk_resource_policies
-  }]
+  }] : []
   security_level = local.blue_instance_template["security_level"]
   tags           = var.tags
   metadata       = var.metadata
@@ -93,7 +93,7 @@ module secure_instance_template_green {
   auto_delete          = !var.stateful_boot
   disk_size_gb         = var.boot_disk_size
   boot_device_name     = "${var.name}-${var.zone}-boot"
-  additional_disks = [{
+  additional_disks = var.persistent_disk ? [{
     boot         = false
     auto_delete  = false
     device_name  = "${var.name}-${var.zone}-data"
@@ -103,7 +103,7 @@ module secure_instance_template_green {
     mode         = "READ_WRITE"
     interface    = var.security_level == "confidential-1" ? "NVME" : "SCSI"
     resource_policies = var.disk_resource_policies
-  }]
+  }] : []
   security_level = local.green_instance_template["security_level"]
   tags           = var.tags
   metadata       = var.metadata

--- a/gcp/secure_swarm_node/main.tf
+++ b/gcp/secure_swarm_node/main.tf
@@ -46,6 +46,7 @@ module secure_instance_template_blue {
   network_ip           = var.blue_instance_template.network_ip == null ? var.network_ip : var.blue_instance_template.network_ip[var.zone]
   access_config        = var.blue_instance_template.access_config == null ?  var.access_config: var.blue_instance_template.access_config
   on_host_maintenance  = local.blue_instance_template["security_level"]  == "confidential-1" ? "TERMINATE" : "MIGRATE"
+  disk_size_gb         = var.boot_disk_size
   disk_interface       = var.security_level == "confidential-1" ? "NVME" : "SCSI"
   auto_delete          = !var.stateful_boot
   additional_disks     = [{

--- a/gcp/secure_swarm_node/main.tf
+++ b/gcp/secure_swarm_node/main.tf
@@ -90,6 +90,7 @@ module secure_instance_template_green {
   on_host_maintenance  = local.green_instance_template["security_level"]  == "confidential-1" ? "TERMINATE" : "MIGRATE"
   disk_interface       = var.security_level == "confidential-1" ? "NVME" : "SCSI"
   auto_delete          = !var.stateful_boot
+  disk_size_gb         = var.boot_disk_size
   boot_device_name     = "${var.name}-${var.zone}-boot"
   additional_disks = [{
     boot         = false

--- a/gcp/secure_swarm_node/vars.tf
+++ b/gcp/secure_swarm_node/vars.tf
@@ -47,6 +47,12 @@ variable "stateful_boot_delete_rule" {
   default = "ON_PERMANENT_INSTANCE_DELETION"
 }
 
+variable "persistent_disk" {
+  type = bool
+  description = "Whether to attach a persistent disk to the instance (default true)"
+  default = true
+}
+
 variable "disk_size" {
   type    = number
   description = "Size of the persistent disk in GB"
@@ -54,7 +60,7 @@ variable "disk_size" {
 }
 
 variable "disk_type" {
-  description = "Type of disk to attach to instance, default is standard persistent disk"
+  description = "Type of persistent disk to attach to instance, default is standard persistent disk"
   type    = string
   default = "pd-standard"
 }

--- a/gcp/secure_swarm_node/vars.tf
+++ b/gcp/secure_swarm_node/vars.tf
@@ -93,6 +93,12 @@ variable "version_name" {
   default = null
 }
 
+variable "boot_disk_size" {
+  description = "Size of the boot disk in GB"
+  type = number
+  default = 10
+}
+
 variable "source_image" {
   description = "Source disk image. If neither source_image nor source_image_family is specified, defaults to the latest public Debian image."
   default     = ""
@@ -213,3 +219,4 @@ variable wait_for_instances {
   type = bool
   default = false
 }
+


### PR DESCRIPTION
Add `persistent_disk` variable to make persistent disk optional (`false` to have no persistent disk, `true` is default)
Add post-deployment documentation on disk formatting