### PR TITLE
Add regional instance group

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -37,7 +37,7 @@ jobs:
 
     # Install gcoud sdk and set the service account
     - name: Setup Cloud SDK
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{secrets.GCP_SA_KEY}}
         export_default_credentials: true

--- a/gcp/compute_engine/instance_template/main.tf
+++ b/gcp/compute_engine/instance_template/main.tf
@@ -109,7 +109,7 @@ resource google_compute_instance_template self {
     subnetwork_project = var.subnetwork_project == null ? var.project_id : var.subnetwork_project
     network_ip         = var.network_ip
     dynamic "access_config" {
-      for_each = lookup(var.access_config, var.zone, [])
+      for_each = var.access_config
       content {
         nat_ip       = lookup(access_config.value, "nat_ip", null)
         network_tier = lookup(access_config.value, "network_tier", null)

--- a/gcp/compute_engine/instance_template/vars.tf
+++ b/gcp/compute_engine/instance_template/vars.tf
@@ -237,8 +237,8 @@ variable security_level {
 # Public IP
 ###########################
 variable "access_config" {
-  description = "Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet."
-  type = map(list(map(string)))
-  default = {}
+  description = "List of access configurations, i.e. IPs via which the VM instance can be accessed via the Internet."
+  type = list(map(string))
+  default = []
 }
 

--- a/gcp/secure_swarm_node/README.md
+++ b/gcp/secure_swarm_node/README.md
@@ -118,15 +118,13 @@ module "secure_swarm_a" {
     name              = "test-check"
     initial_delay_sec = 180
   }]
-  access_config = {
-    a = [{nat_ip = "35.0.0.2"}]
+  access_config = [{nat_ip = "35.0.0.2"}]
   }
   blue_instance_template = {}
   green_instance_template = {
     network = "network"
     subnetwork = "subnet"
-    network_ip = {
-      a = "10.0.0.2"
+    network_ip = "10.0.0.2"
     }
   }
 }
@@ -143,16 +141,12 @@ module "secure_swarm_b" {
     name              = "test-check"
     initial_delay_sec = 180
   }]
-  access_config = {
-    b = [{nat_ip = "35.0.0.3"}]
-  }
+  access_config = [{nat_ip = "35.0.0.3"}]
   blue_instance_template = {}
   green_instance_template = {
     network = "network"
     subnetwork = "subnet"
-    network_ip = {
-      b = "10.0.0.3"
-    }
+    network_ip = "10.0.0.3"
   }
 }
 ```

--- a/gcp/secure_swarm_node/locals.tf
+++ b/gcp/secure_swarm_node/locals.tf
@@ -1,4 +1,5 @@
 locals {
+  name = var.zone == null ? var.name : "${var.name}-${var.zone}"
   blue_instance_template = lookup(var.blue_instance_template, "security_level", null) == null ? merge(
     var.blue_instance_template, { security_level = var.security_level
   }) : contains(["secure-1", "confidential-1"], var.blue_instance_template["security_level"]) ? var.blue_instance_template : merge(var.blue_instance_template, { security_level = "confidential-1" })
@@ -8,7 +9,7 @@ locals {
   ) : contains(["secure-1", "confidential-1"], var.green_instance_template["security_level"]) ? var.green_instance_template : merge(var.green_instance_template, { security_level = "confidential-1" })
 
   stateful_boot_disk = var.stateful_boot ? [{
-    device_name = "${var.name}-${var.zone}-boot"
+    device_name = "${local.name}-boot"
     delete_rule = var.stateful_boot_delete_rule
   }] : []
 }

--- a/gcp/secure_swarm_node/vars.tf
+++ b/gcp/secure_swarm_node/vars.tf
@@ -10,6 +10,13 @@ variable "project" {
 
 variable "zone"{
   type = string
+  default = null
+}
+
+variable "stateful_instance_group" {
+  description = "Whether the MIG should be stateful (true) or not (false)"
+  type = bool
+  default = true
 }
 
 variable "region" {
@@ -73,8 +80,9 @@ variable "disk_resource_policies" {
 
 //Network configuration
 variable "access_config" {
-  type = map(list(map(string)))
-  default = {}
+  description = "List of access configurations, i.e. IPs via which the VM instance can be accessed via the Internet."
+  type = list(map(string))
+  default = []
 }
 variable "network" {
   type    = string
@@ -146,8 +154,8 @@ variable blue_instance_template {
     source_image_project = optional(string)
     network = optional(string)
     subnetwork = optional(string)
-    network_ip = optional(map(string))
-    access_config = optional(map(list(map(string))))
+    network_ip = optional(string)
+    access_config = optional(list(map(string)))
     security_level = optional(string)
     service_account_scopes = optional(set(string))
   })
@@ -162,8 +170,8 @@ variable green_instance_template {
     source_image_project = optional(string)
     network = optional(string)
     subnetwork = optional(string)
-    network_ip = optional(map(string))
-    access_config = optional(map(list(map(string))))
+    network_ip = optional(string)
+    access_config = optional(list(map(string)))
     security_level = optional(string)
     service_account_scopes = optional(set(string))
   })
@@ -191,6 +199,7 @@ variable "named_ports" {
 variable "update_policy" {
   description = "The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy"
   type = list(object({
+    instance_redistribution_type = optional(string)
     max_surge_fixed              = optional(number)
     max_surge_percent            = optional(number)
     max_unavailable_fixed        = optional(number)
@@ -206,10 +215,6 @@ variable "update_policy" {
 variable target_size {
   description = "Target Size of the Managed Instance Group"
   default = 0
-  validation {
-    condition = var.target_size <= 1
-    error_message = "Target size cannot be more than 1 for stateful managed instance groups."
-  }
 }
 
 variable "deployment_version" {
@@ -218,6 +223,7 @@ variable "deployment_version" {
     error_message = "Invalid deployment version."
   }
   type = string
+  default = "green"
 }
 
 variable wait_for_instances {


### PR DESCRIPTION
* If the `zone` variable is not set, a regional MIG is deployed instead of the default zonal one.
  * Local variable used for setting `local.name` to either `${var.name}` or `${var.name}-${var.zone}` depending on type of deployment 
* Stateless MIG deployments are now possible by setting `stateful_instance_group=false`. The `stateful_disk` block for the persistent disk is now dynamic, with the stateful disk being configured if both `stateful_instance_group` and `persistent_disk` are true.
* Updated documentation
* BREAKING: Updated the format of both the `access_config` and the `network_ip` variables to remove references to `zone`. Previous configuration was too specific to zonal MIG deployments:

  ```hcl
    access_config = {
      a = [{nat_ip = "35.0.0.2"}]
    }
    network_ip = {
      a = "10.0.0.2"
     } 
  ```
  The new configuration would be:
  ```hcl
    access_config = [{nat_ip = "35.0.0.2"}]
    network_ip = "10.0.0.2"
  ```
  As the module would only be deploying to one zone anyway