### PR TITLE
Changes causing forced replacements

### DIFF
--- a/gcp/secure_swarm_node/main.tf
+++ b/gcp/secure_swarm_node/main.tf
@@ -59,7 +59,7 @@ module secure_instance_template_blue {
   disk_interface       = var.security_level == "confidential-1" ? "NVME" : "SCSI"
   auto_delete          = !var.stateful_boot
   disk_size_gb         = var.boot_disk_size
-  boot_device_name     = "${local.name}-boot"
+  boot_device_name     = var.boot_device_name
   additional_disks     = var.persistent_disk ? [{
     boot         = false
     auto_delete  = false
@@ -102,7 +102,7 @@ module secure_instance_template_green {
   disk_interface       = var.security_level == "confidential-1" ? "NVME" : "SCSI"
   auto_delete          = !var.stateful_boot
   disk_size_gb         = var.boot_disk_size
-  boot_device_name     = "${local.name}-boot"
+  boot_device_name     = var.boot_device_name
   additional_disks     = var.persistent_disk ? [{
     boot         = false
     auto_delete  = false

--- a/gcp/secure_swarm_node/vars.tf
+++ b/gcp/secure_swarm_node/vars.tf
@@ -113,6 +113,12 @@ variable "boot_disk_size" {
   default = 10
 }
 
+variable "boot_device_name" {
+  description = "Device name for the boot disk"
+  type = string
+  default     = null
+}
+
 variable "source_image" {
   description = "Source disk image. If neither source_image nor source_image_family is specified, defaults to the latest public Debian image."
   default     = ""


### PR DESCRIPTION
Changes from v1.8.0 included adding `instance_redistribution_type` to the `update_policy` variable as it is an attribute for the `regional_instance_group_manager` update policy.  
This forces the `time_static.self` update to trigger as there would be changes to the `update_policy`, as it would include the new attribute, even for zonal instance group managers.
Added a separate `regional_update_policy` which includes `instance_redistribution_type`, and removed that attribute from `update_policy`.  
Also added a separate `time_static.regional_mig_update` resource, to manage updates for the regional instance group manager

The variable `boot_device_name` was also configured to be `${local.}-boot`, but prior to v1.8.0 as not configured at all. This causes forced replacements as the default for the `instance_template` module is `null` (which would name the device something like `persistent-disk-0`).  
Update to use a variable to avoid forced change