### PR TITLE
Develop

### DIFF
--- a/gcp/secure_swarm_node/main.tf
+++ b/gcp/secure_swarm_node/main.tf
@@ -27,7 +27,7 @@ resource time_static self {
 module secure_instance_template_blue {
   source      = "../compute_engine/instance_template"
   project_id  = var.project
-  description = "Secure Swarm Node template"
+  description = var.instance_template_description
   service_account = {
     email  = local.service_account_email
     scopes = var.blue_instance_template.service_account_scopes == null ? var.service_account_scopes : var.blue_instance_template.service_account_scopes
@@ -70,7 +70,7 @@ module secure_instance_template_blue {
 module secure_instance_template_green {
   source      = "../compute_engine/instance_template"
   project_id  = var.project
-  description = "Secure Swarm Node template"
+  description = var.instance_template_description
   service_account = {
     email  = local.service_account_email
     scopes = var.green_instance_template.service_account_scopes == null ? var.service_account_scopes : var.green_instance_template.service_account_scopes

--- a/gcp/secure_swarm_node/main.tf
+++ b/gcp/secure_swarm_node/main.tf
@@ -24,6 +24,16 @@ resource time_static self {
   }
 }
 
+resource time_static regional_mig_update {
+  triggers = {
+    deployment_version = var.deployment_version
+    instance = var.deployment_version == "blue" ? module.secure_instance_template_blue.fingerprint : module.secure_instance_template_green.fingerprint
+    regional_update_policy = jsonencode(var.regional_update_policy)
+    health_check = jsonencode(var.health_check)
+    named_ports = jsonencode(var.named_ports)
+  }
+}
+
 module secure_instance_template_blue {
   source      = "../compute_engine/instance_template"
   project_id  = var.project
@@ -49,7 +59,7 @@ module secure_instance_template_blue {
   disk_interface       = var.security_level == "confidential-1" ? "NVME" : "SCSI"
   auto_delete          = !var.stateful_boot
   disk_size_gb         = var.boot_disk_size
-  boot_device_name     = "${local.name}-boot"
+  boot_device_name     = var.boot_device_name
   additional_disks     = var.persistent_disk ? [{
     boot         = false
     auto_delete  = false
@@ -92,7 +102,7 @@ module secure_instance_template_green {
   disk_interface       = var.security_level == "confidential-1" ? "NVME" : "SCSI"
   auto_delete          = !var.stateful_boot
   disk_size_gb         = var.boot_disk_size
-  boot_device_name     = "${local.name}-boot"
+  boot_device_name     = var.boot_device_name
   additional_disks     = var.persistent_disk ? [{
     boot         = false
     auto_delete  = false
@@ -193,7 +203,7 @@ resource google_compute_region_instance_group_manager self {
   target_size        = var.target_size
 
   version {
-    name              = var.version_name == null ? formatdate("YYYYMMDDhhmm", time_static.self.rfc3339) : var.version_name
+    name              = var.version_name == null ? formatdate("YYYYMMDDhhmm", time_static.regional_mig_update.rfc3339) : var.version_name
     instance_template = var.deployment_version == "blue" ? module.secure_instance_template_blue.self_link : module.secure_instance_template_green.self_link
   }
 

--- a/gcp/secure_swarm_node/vars.tf
+++ b/gcp/secure_swarm_node/vars.tf
@@ -146,6 +146,11 @@ variable security_level {
   }
 }
 
+variable "instance_template_description" {
+  type = string
+  default = "Secure Swarm Node template"
+}
+
 variable blue_instance_template {
   type = object({
     machine_type = optional(string)

--- a/gcp/secure_swarm_node/vars.tf
+++ b/gcp/secure_swarm_node/vars.tf
@@ -113,6 +113,12 @@ variable "boot_disk_size" {
   default = 10
 }
 
+variable "boot_device_name" {
+  description = "Device name for the boot disk"
+  type = string
+  default     = null
+}
+
 variable "source_image" {
   description = "Source disk image. If neither source_image nor source_image_family is specified, defaults to the latest public Debian image."
   default     = ""
@@ -202,7 +208,22 @@ variable "named_ports" {
 
 
 variable "update_policy" {
-  description = "The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy"
+  description = "The update policy for zonal instance group"
+  type = list(object({
+    max_surge_fixed              = optional(number)
+    max_surge_percent            = optional(number)
+    max_unavailable_fixed        = optional(number)
+    max_unavailable_percent      = optional(number)
+    min_ready_sec                = optional(number)
+    minimal_action               = string
+    type                         = string
+    replacement_method           = optional(string)
+  }))
+  default = []
+}
+
+variable "regional_update_policy" {
+  description = "The update policy for regional instance group"
   type = list(object({
     instance_redistribution_type = optional(string)
     max_surge_fixed              = optional(number)


### PR DESCRIPTION
Bug fixes: 
* Make separate `regional_update_policy` variable for regional instance group managers to stop forced recreation existing zonal managed instance groups.
* `boot_device_name` variable added to replace static value that was causing forced recreation of existing instance templates