### PR TITLE
Include extra attibutes for blue/green deployments

### DIFF
--- a/gcp/secure_swarm_node/README.md
+++ b/gcp/secure_swarm_node/README.md
@@ -52,6 +52,8 @@ If `zone` is null, a regional MIG will be deployed instead, and will just have t
 
 The MIG can either be stateful (default) or set to stateless by setting `stateful_instance_group=false`.
 If using a persistent disks, the maximum `target_size` is 1 (see [troubleshooting](#the-instance-template-cannot-be-used-to-create-more-than-one-instance-per-zone)).
+The persistent disk created using the instance template from this module will have the device_name of `${var.name}-${var.zone}-data` (e.g "secure-swarm-a-data").
+If using a stateful boot disk, the device name is configured using the `boot_device_name` (defaults to `${var.name}-${var.zone}-boot`). 
 
 If the `update_policy` or `regional_update_policy` is configured to do so, the instances deployed from MIG will update when the version changes.
 If `version_name` is not set, a timestamp is used for the `version` configuration. 
@@ -244,3 +246,11 @@ Likely scenarios this occurs in:
 ```
 The persistent-disk name in this module is set to be `${var.name}-data`. 
 Set the `target_size` to a maximum of 1 if using a persistent disk. 
+
+
+### Invalid value for field 'resource.versions[0].instanceTemplate': <Instance-Template>. Instance template <Instance-template> does not contain stateful disks [secure-swarm-a-boot]., invalid
+This occurs when the device name of a MIG stateful disk is not defined in the instance template for the MIG. 
+This issue occurs when upgrading module versions from 1.6.0 to versions before 1.8.3. 
+The MIG was hardcoded to have a stateful boot disk named `${var.name}-${var.zone}-boot`, if that did not match the `device_name` of the boot disk in the instance template. This error would occur.
+
+To resolve this update to version 1.8.3+, where setting the `boot_device_name` will ensure the stateful disk configuration in the MIG matches the instance template

--- a/gcp/secure_swarm_node/locals.tf
+++ b/gcp/secure_swarm_node/locals.tf
@@ -1,14 +1,49 @@
 locals {
   name = var.zone == null ? var.name : "${var.name}-${var.zone}"
-  blue_instance_template = lookup(var.blue_instance_template, "security_level", null) == null ? merge(
-    var.blue_instance_template, { security_level = var.security_level
-  }) : contains(["secure-1", "confidential-1"], var.blue_instance_template["security_level"]) ? var.blue_instance_template : merge(var.blue_instance_template, { security_level = "confidential-1" })
-
-  green_instance_template = lookup(var.green_instance_template, "security_level", null) == null ? merge(
-    var.green_instance_template, { security_level = var.security_level }
-  ) : contains(["secure-1", "confidential-1"], var.green_instance_template["security_level"]) ? var.green_instance_template : merge(var.green_instance_template, { security_level = "confidential-1" })
 
   boot_device_name = var.boot_device_name == null ? "${local.name}-boot" : var.boot_device_name
+
+  blue_instance_template = {
+    description            = var.instance_template_description
+    service_account_scopes = var.blue_instance_template.service_account_scopes == null ? var.service_account_scopes : var.blue_instance_template.service_account_scopes
+    machine_type           = var.blue_instance_template.machine_type == null ? var.machine_type : var.blue_instance_template.machine_type
+    source_image           = var.blue_instance_template.source_image == null ? var.source_image : var.blue_instance_template.source_image
+    source_image_family    = var.blue_instance_template.source_image_family == null ? var.source_image_family : var.blue_instance_template.source_image_family
+    source_image_project   = var.blue_instance_template.source_image_project == null ? var.source_image_project : var.blue_instance_template.source_image_project
+    network                = var.blue_instance_template.network == null ? var.network : var.blue_instance_template.network
+    subnetwork             = var.blue_instance_template.subnetwork == null? var.subnetwork : var.blue_instance_template.subnetwork
+    network_ip             = var.blue_instance_template.network_ip == null ? var.network_ip : var.blue_instance_template.network_ip
+    access_config          = var.blue_instance_template.access_config == null?  var.access_config: var.blue_instance_template.access_config
+    security_level         = var.blue_instance_template.security_level == null ? var.security_level : contains(["secure-1", "confidential-1"], var.blue_instance_template["security_level"]) ? var.blue_instance_template["security_level"] : null
+    boot_disk_size         = var.blue_instance_template.boot_disk_size == null ? var.boot_disk_size : var.blue_instance_template.boot_disk_size
+    boot_device_name       = var.blue_instance_template.boot_device_name == null ? var.boot_device_name == null ? "${local.name}-boot" : var.boot_device_name : var.blue_instance_template.boot_device_name
+    disk_size              = var.blue_instance_template.disk_size == null ? var.disk_size : var.blue_instance_template.disk_size
+    disk_type              = var.blue_instance_template.disk_type == null ? var.disk_type : var.blue_instance_template.disk_type
+    resource_policies      = var.blue_instance_template.disk_resource_policies == null ? var.disk_resource_policies : var.blue_instance_template.disk_resource_policies
+    tags                   = var.blue_instance_template.tags == null ? var.tags : var.blue_instance_template.tags
+    metadata               = var.blue_instance_template.metadata == null ? var.metadata : var.blue_instance_template.metadata
+  }
+
+  green_instance_template = {
+    description            = var.instance_template_description
+    service_account_scopes = var.green_instance_template.service_account_scopes == null ? var.service_account_scopes : var.green_instance_template.service_account_scopes
+    machine_type           = var.green_instance_template.machine_type == null ? var.machine_type : var.green_instance_template.machine_type
+    source_image           = var.green_instance_template.source_image == null ? var.source_image : var.green_instance_template.source_image
+    source_image_family    = var.green_instance_template.source_image_family == null ? var.source_image_family : var.green_instance_template.source_image_family
+    source_image_project   = var.green_instance_template.source_image_project == null ? var.source_image_project : var.green_instance_template.source_image_project
+    network                = var.green_instance_template.network == null ? var.network : var.green_instance_template.network
+    subnetwork             = var.green_instance_template.subnetwork == null? var.subnetwork : var.green_instance_template.subnetwork
+    network_ip             = var.green_instance_template.network_ip == null ? var.network_ip : var.green_instance_template.network_ip
+    access_config          = var.green_instance_template.access_config == null?  var.access_config: var.green_instance_template.access_config
+    security_level         = var.green_instance_template.security_level == null ? var.security_level : contains(["secure-1", "confidential-1"], var.green_instance_template["security_level"]) ? var.green_instance_template["security_level"] : null
+    boot_disk_size         = var.green_instance_template.boot_disk_size == null ? var.boot_disk_size : var.green_instance_template.boot_disk_size
+    boot_device_name       = var.green_instance_template.boot_device_name == null ? var.boot_device_name == null ? "${local.name}-boot" : var.boot_device_name : var.green_instance_template.boot_device_name
+    disk_size              = var.green_instance_template.disk_size == null ? var.disk_size : var.green_instance_template.disk_size
+    disk_type              = var.green_instance_template.disk_type == null ? var.disk_type : var.green_instance_template.disk_type
+    resource_policies      = var.green_instance_template.disk_resource_policies == null ? var.disk_resource_policies : var.green_instance_template.disk_resource_policies
+    tags                   = var.green_instance_template.tags == null ? var.tags : var.green_instance_template.tags
+    metadata               = var.green_instance_template.metadata == null ? var.metadata : var.green_instance_template.metadata
+  }
 
   stateful_boot_disk = var.stateful_boot ? [{
     device_name = local.boot_device_name

--- a/gcp/secure_swarm_node/main.tf
+++ b/gcp/secure_swarm_node/main.tf
@@ -37,86 +37,86 @@ resource time_static regional_mig_update {
 module secure_instance_template_blue {
   source      = "../compute_engine/instance_template"
   project_id  = var.project
-  description = var.instance_template_description
+  description = local.blue_instance_template.description
   service_account = {
     email  = local.service_account_email
-    scopes = var.blue_instance_template.service_account_scopes == null ? var.service_account_scopes : var.blue_instance_template.service_account_scopes
+    scopes = local.blue_instance_template.service_account_scopes
   }
   region               = var.region
   zone                 = var.zone
   enable_shielded_vm   = true
   name_prefix          = "${local.name}-blue-"
-  machine_type         = var.blue_instance_template.machine_type == null ? var.machine_type : var.blue_instance_template.machine_type
-  source_image         = var.blue_instance_template.source_image == null ? var.source_image : var.blue_instance_template.source_image
-  source_image_family  = var.blue_instance_template.source_image_family == null ? var.source_image_family : var.blue_instance_template.source_image_family
-  source_image_project = var.blue_instance_template.source_image_project == null ? var.source_image_project : var.blue_instance_template.source_image_project
-  subnetwork_project   = var.blue_instance_template.subnetwork == null ? null : var.project
-  network              = var.blue_instance_template.network == null ? var.network : var.blue_instance_template.network
-  subnetwork           = var.blue_instance_template.subnetwork == null ? var.subnetwork : var.blue_instance_template.subnetwork
-  network_ip           = var.blue_instance_template.network_ip == null ? var.network_ip : var.blue_instance_template.network_ip
-  access_config        = var.blue_instance_template.access_config == null ?  var.access_config: var.blue_instance_template.access_config
-  on_host_maintenance  = local.blue_instance_template["security_level"]  == "confidential-1" ? "TERMINATE" : "MIGRATE"
-  disk_interface       = var.security_level == "confidential-1" ? "NVME" : "SCSI"
+  machine_type         = local.blue_instance_template.machine_type
+  source_image         = local.blue_instance_template.source_image
+  source_image_family  = local.blue_instance_template.source_image_family
+  source_image_project = local.blue_instance_template.source_image_project
+  network              = local.blue_instance_template.network
+  subnetwork           = local.blue_instance_template.subnetwork
+  subnetwork_project   = local.blue_instance_template.subnetwork == null ? null : var.project
+  network_ip           = local.blue_instance_template.network_ip
+  access_config        = local.blue_instance_template.access_config
+  on_host_maintenance  = local.blue_instance_template.security_level  == "confidential-1" ? "TERMINATE" : "MIGRATE"
+  disk_interface       = local.blue_instance_template.security_level == "confidential-1" ? "NVME" : "SCSI"
   auto_delete          = !var.stateful_boot
-  disk_size_gb         = var.boot_disk_size
-  boot_device_name     = local.boot_device_name
+  disk_size_gb         = local.blue_instance_template.boot_disk_size
+  boot_device_name     = local.blue_instance_template.boot_device_name
   additional_disks     = var.persistent_disk ? [{
     boot         = false
     auto_delete  = false
     device_name  = "${local.name}-data"
     disk_name    = "${local.name}-data"
-    disk_size_gb = var.disk_size
-    disk_type    = var.disk_type
+    disk_size_gb = local.blue_instance_template.disk_size
+    disk_type    = local.blue_instance_template.disk_type
     mode         = "READ_WRITE"
-    interface    = var.security_level == "confidential-1" ? "NVME" : "SCSI"
-    resource_policies = var.disk_resource_policies
+    interface    = local.blue_instance_template.security_level == "confidential-1" ? "NVME" : "SCSI"
+    resource_policies = local.blue_instance_template.resource_policies
   }] : []
-  security_level = local.blue_instance_template["security_level"]
-  tags           = var.tags
-  metadata       = var.metadata
+  security_level = local.blue_instance_template.security_level
+  tags           = local.blue_instance_template.tags
+  metadata       = local.blue_instance_template.metadata
 }
 
 
 module secure_instance_template_green {
   source      = "../compute_engine/instance_template"
   project_id  = var.project
-  description = var.instance_template_description
+  description = local.green_instance_template.description
   service_account = {
     email  = local.service_account_email
-    scopes = var.green_instance_template.service_account_scopes == null ? var.service_account_scopes : var.green_instance_template.service_account_scopes
+    scopes = local.green_instance_template.service_account_scopes
   }
   region               = var.region
   zone                 = var.zone
   enable_shielded_vm   = true
   name_prefix          = "${local.name}-green-"
-  machine_type         = var.green_instance_template.machine_type == null ? var.machine_type : var.green_instance_template.machine_type
-  source_image         = var.green_instance_template.source_image == null ? var.source_image : var.green_instance_template.source_image
-  source_image_family  = var.green_instance_template.source_image_family == null ? var.source_image_family : var.green_instance_template.source_image_family
-  source_image_project = var.green_instance_template.source_image_project == null ? var.source_image_project : var.green_instance_template.source_image_project
-  subnetwork_project   = var.green_instance_template.subnetwork == null ? null : var.project
-  network              = var.green_instance_template.network == null ? var.network : var.green_instance_template.network
-  subnetwork           = var.green_instance_template.subnetwork == null? var.subnetwork : var.green_instance_template.subnetwork
-  network_ip           = var.green_instance_template.network_ip == null ? var.network_ip : var.green_instance_template.network_ip
-  access_config        = var.green_instance_template.access_config == null?  var.access_config: var.green_instance_template.access_config
-  on_host_maintenance  = local.green_instance_template["security_level"]  == "confidential-1" ? "TERMINATE" : "MIGRATE"
-  disk_interface       = var.security_level == "confidential-1" ? "NVME" : "SCSI"
+  machine_type         = local.green_instance_template.machine_type
+  source_image         = local.green_instance_template.source_image
+  source_image_family  = local.green_instance_template.source_image_family
+  source_image_project = local.green_instance_template.source_image_project
+  network              = local.green_instance_template.network
+  subnetwork           = local.green_instance_template.subnetwork
+  subnetwork_project   = local.green_instance_template.subnetwork == null ? null : var.project
+  network_ip           = local.green_instance_template.network_ip
+  access_config        = local.green_instance_template.access_config
+  on_host_maintenance  = local.green_instance_template.security_level  == "confidential-1" ? "TERMINATE" : "MIGRATE"
+  disk_interface       = local.green_instance_template.security_level == "confidential-1" ? "NVME" : "SCSI"
   auto_delete          = !var.stateful_boot
-  disk_size_gb         = var.boot_disk_size
-  boot_device_name     = local.boot_device_name
+  disk_size_gb         = local.green_instance_template.boot_disk_size
+  boot_device_name     = local.green_instance_template.boot_device_name
   additional_disks     = var.persistent_disk ? [{
     boot         = false
     auto_delete  = false
     device_name  = "${local.name}-data"
     disk_name    = "${local.name}-data"
-    disk_size_gb = var.disk_size
-    disk_type    = var.disk_type
+    disk_size_gb = local.green_instance_template.disk_size
+    disk_type    = local.green_instance_template.disk_type
     mode         = "READ_WRITE"
-    interface    = var.security_level == "confidential-1" ? "NVME" : "SCSI"
-    resource_policies = var.disk_resource_policies
+    interface    = local.green_instance_template.security_level == "confidential-1" ? "NVME" : "SCSI"
+    resource_policies = local.green_instance_template.resource_policies
   }] : []
-  security_level = local.green_instance_template["security_level"]
-  tags           = var.tags
-  metadata       = var.metadata
+  security_level = local.green_instance_template.security_level
+  tags           = local.green_instance_template.tags
+  metadata       = local.green_instance_template.metadata
 }
 
 resource google_compute_instance_group_manager self {

--- a/gcp/secure_swarm_node/vars.tf
+++ b/gcp/secure_swarm_node/vars.tf
@@ -159,6 +159,8 @@ variable "instance_template_description" {
 
 variable blue_instance_template {
   type = object({
+    description = optional(string)
+    service_account_scopes = optional(set(string))
     machine_type = optional(string)
     source_image = optional(string)
     source_image_family = optional(string)
@@ -168,13 +170,22 @@ variable blue_instance_template {
     network_ip = optional(string)
     access_config = optional(list(map(string)))
     security_level = optional(string)
-    service_account_scopes = optional(set(string))
+    boot_disk_size = optional(number)
+    boot_device_name = optional(string)
+    persistent_disk = optional(bool)
+    disk_size = optional(string)
+    disk_type = optional(string)
+    disk_resource_policies = optional(list(string))
+    tags = optional(list(string))
+    metadata = optional(map(string))
   })
   default = {}
 }
 
 variable green_instance_template {
   type = object({
+    description = optional(string)
+    service_account_scopes = optional(set(string))
     machine_type = optional(string)
     source_image = optional(string)
     source_image_family = optional(string)
@@ -184,7 +195,14 @@ variable green_instance_template {
     network_ip = optional(string)
     access_config = optional(list(map(string)))
     security_level = optional(string)
-    service_account_scopes = optional(set(string))
+    boot_disk_size = optional(number)
+    boot_device_name = optional(string)
+    persistent_disk = optional(bool)
+    disk_size = optional(string)
+    disk_type = optional(string)
+    disk_resource_policies = optional(list(string))
+    tags = optional(list(string))
+    metadata = optional(map(string))
   })
   default = {}
 }


### PR DESCRIPTION
* Added all Instance Group attributes to the `blue_instance_template` and `green_instance_template` variables
* Moved the instance template module logic to `locals.tf`
* Updated documentation to include note about `boot_device_name` issues 