### PR TITLE
Variable type typo

### DIFF
--- a/gcp/compute_engine/serverless_neg_https_lb/variables.tf
+++ b/gcp/compute_engine/serverless_neg_https_lb/variables.tf
@@ -83,6 +83,6 @@ variable enable_log_config {
 
 variable https_redirect {
   description = "Set to `true` to enable https redirect on the lb."
-  type = book
+  type = bool
   default = false
 }


### PR DESCRIPTION
`https_redirect` type was `book` instead of `bool`