### PR TITLE
MPS-50 Create workload identity federation module

### DIFF
--- a/gcp/iam/workload_identity_federation/README.md
+++ b/gcp/iam/workload_identity_federation/README.md
@@ -1,0 +1,212 @@
+# Workload Identity Federation
+
+This module deploys a Workload Identity Pool, and it's Workload Identity Pool Providers (IDPs), for Workload Identity Federation.
+[Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation) allows external entities
+to access Google Cloud resources without using service account keys.
+
+This module implements templated configurations for commonly used external entities that use OIDC, including:
+* Azure
+* Bitbucket Pipelines
+* CircleCi
+* GitHub Actions
+* GitLab
+* Terraform Cloud
+
+See the [configuration](#configuration) section for implementation details.
+
+## Configuration
+This module takes the following variables:
+* `project_id` - The project the pool is defined in
+* `workload_identity_pool` - Definition of a pool and its providers with the following attributes:
+
+| Key                                |     Type     | Required | Description                                                                                                                                       |                                                           Default                                                           |
+|:-----------------------------------|:------------:|:--------:|:--------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------:|
+| `pool_id`                          |    string    |   true   | ID for the pool                                                                                                                                   |                                                            none                                                             |
+| `display_name`                     |    string    |  false   | The display name of the pool if different than the pool-id                                                                                        |                                                           pool-id                                                           |
+| `description`                      |    string    |  false   | Description for the pool                                                                                                                          |                                                            none                                                             |
+| `disabled`                         |     bool     |  false   | Whether the pool is disabled                                                                                                                      |                                                            false                                                            |
+| `providers`                        | map(object)  |  false   | Map with of provider-id and it's attributes                                                                                                       |                                                            none                                                             |
+| `providers.attribute_mapping`      | map(string)  |  false   | Maps attributes from OIDC claim to google attributes. `google.sub` is required, e.g. `google.sub=assertion.sub`                                   |                                                            none                                                             |
+| `providers.display_name`           |    string    |  false   | Display name for the provider                                                                                                                     |                                                         provider-id                                                         |
+| `providers.description`            |    string    |  false   | Description for the provider                                                                                                                      |                                                            none                                                             |
+| `providers.disabled`               |     bool     |  false   | Whether the provider is disabled                                                                                                                  |                                                            false                                                            |
+| `providers.attribute_condition`    |    string    |  false   | An expression to define required values for assertion claims                                                                                      |                                                            none                                                             |
+| `providers.owner`                  |    string    |  false   | If using a preconfigured `providers.oidc.issuer` this references the "owner" of the issuer, i.e. the organization or username.                    |                                                            none                                                             |
+| `providers.workspace_uuid`         |    string    |  false   | If `providers.oidc.issuer` is `bitbucket-pipelines`, this references the workspace uuid with the format: `{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}` |                                                            none                                                             |
+| `providers.oidc`                   |     map      |  false   | The configuration for an OIDC provider (Either this OR `aws` block can be set)                                                                    |                                                            none                                                             |
+| `providers.oidc.issuer`            |    string    |   true   | The preconfigured template to use, or the OIDC issuer uri                                                                                         |                                                            none                                                             |
+| `providers.oidc.allowed_audiences` | list(string) |  false   | Acceptable values for the `aud` field                                                                                                             | `"https://iam.googleapis.com/projects/project-number/locations/global/workloadIdentityPools/pool-id/providers/provider-id"` |
+| `providers.aws`                    |     map      |  false   | The configuration for an AWS provider (Either this OR `oidc` block can be set)                                                                    |                                                            none                                                             |
+| `providersaws.account_id`          |     map      |   true   | The id of the client aws account                                                                                                                  |                                                            none                                                             |
+
+#### Example
+```terraform
+module workload_identity_pool {
+  source                 = "github.com/mesoform/terraform-infrastructure-modules//gcp/iam/workload_identity_federation"
+  project_id             = "project_id"
+  workload_identity_pool = {
+    pool_id   = "cicd"
+    display_name = "CI/CD pool"
+    providers = {
+      github = {
+        attribute_condition = "assertion.repostory_owner=='Company' && assertion.actor=='personalAccount'"
+        attribute_mapping   = {
+          "google.subject"  = "assertion.repository"
+        }
+        owner = "Company"
+        oidc  = {
+          issuer = "github-actions"
+        }
+      }
+      bitbucket = {
+        owner          = "mesoform"
+        workspace_uuid = "{some-uuid}"
+        oidc           = {
+          issuer = "bitbucket-pipelines"
+        }
+      }
+      unknown = {
+        attribute_mapping = {
+          "google.subject" = "assertion.sub"
+          "attribute.tid"  = "assertion.tid"
+        }
+        oidc = {
+          issuer = "https://unknown.issuer"
+        }
+      }
+    }
+  }
+}
+```
+
+Multiple pools can be configured at once using a `for_each` attribute, e.g.:
+```terraform
+module workload_identity_pools {
+  source                 = "github.com/mesoform/terraform-infrastructure-modules//gcp/iam/workload_identity_federation"
+  for_each               = var.workload_identity_pools
+  project_id             = var.project_id
+  workload_identity_pool = each.value
+}
+```
+where `var.workload_identity_pools` is set as:
+```terraform
+workload_identity_pools = {
+  cicd = {
+    pool_id      = "cicd"
+    display_name = "CI/CD pool"
+    providers    = {
+      github = {
+        attribute_condition = "assertion.repostory_owner=='Company' && assertion.actor=='personalAccount'"
+        attribute_mapping   = {
+          "google.subject" = "assertion.repository"
+        }
+        owner = "Company"
+        oidc  = {
+          issuer = "github-actions"
+        }
+      }
+      bitbucket = {
+        owner          = "mesoform"
+        workspace_uuid = "{some-uuid}"
+        oidc           = {
+          issuer = "bitbucket-pipelines"
+        }
+      }
+      unknown = {
+        attribute_mapping = {
+          "google.subject" = "assertion.sub"
+          "attribute.tid"  = "assertion.tid"
+        }
+        oidc = {
+          issuer = "https://unknown.issuer"
+        }
+      }
+    }
+  }
+  aws = {
+    pool_id      = "aws"
+    display_name = "AWS applications"
+    providers    = {
+      ec2_instance_1 = {
+        attribute_condition = "assertion.arn.startsWith('arn:aws:sts::accountid:assumed-role/')"
+        attribute_mapping   = {
+          "google.subject"             = "assertion.arn"
+          "attribute.account"          = "assertion.account"
+          "attribute.aws_role"         = "assertion.arn.extract('assumed-role/ROLE/')"
+          "attribute.aws_ec2_instance" = "assertion.arn.extract('assumed-role/ROLE_AND_SESSION').extract('/SESSION')"
+        }
+        aws = {
+          account_id = "accountid"
+        }
+      }
+    }
+  }
+}
+```
+
+### Preconfigured defaults
+This module has preconfigured Identity Provider settings for commonly used clients, referred to as "trusted issuers",
+which can be used by setting `providers.oidc.issuer` to one of the issuers from the table below, as well as setting required MCCF attributes.
+
+Full defaults for preconfigured IDP can be found in the [`trusted_issuers.tf`](./trusted_issuers.yaml) file.
+
+#### Trusted issuers
+| Issuer                | Required MCCF attributes                                                              |
+|-----------------------|---------------------------------------------------------------------------------------|
+| `azure`               | - `owner`: Tenant ID of Azure tenant                                                  |
+| `bitbucket-pipelines` | - `owner`: Name of the workspace owner <br> - `workspace_uuid`: UUid of the workspace |
+| `circleci`            | - `owner`: CircleCi Organization ID                                                   |
+| `github-actions`      | - `owner`: Repository owner (i.e. Username/Organization)                              |
+| `gitlab`              | - `owner`: Unique group ID                                                            |
+| `terraform-cloud`     | - `owner`: Terraform Cloud Organization ID                                            |
+
+Each of the providers have a condition configured based on the `owner`/`workspace_uuid` attributes.
+To make a custom condition configure set the `attribute_condition` to a [valid condition](https://cloud.google.com/iam/docs/workload-identity-federation#conditions).
+
+Some of these issuers have a configured default audience different to the Google default
+(i.e. `https://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID`).
+If this Google default audience should be included in the `allowed_audiences` as well as the preconfigured default,
+add `"default"` to the list in `oidc.allowed_audiences`.   
+e.g.
+```terraform
+workload_identity_pool = {
+  pool_id      = "cicd"
+  display_name = "CI/CD pool"
+  providers    = {
+    bitbucket = {
+      owner          = "workspaceName"
+      workspace_uuid = "{some-uuid}"
+      oidc           = {
+        issuer = "bitbucket-pipelines"
+        allowed_audiences = ["default"]
+      }
+    }
+  }
+}
+```
+
+If the Google default audience is the only audience that should be the only allowed audience,
+but the truster issuer has a preconfigured default audience, the provider must be configured manually.
+e.g.
+
+```terraform
+workload_identity_pool = {
+  pool_id      = "cicd"
+  display_name = "CI/CD pool"
+  providers    = {
+    bitbucket = {
+      attributes = {
+        "google.subject" = "assertion.sub"
+        "attribute.workspace_uuid" = "assertion.workspaceUuid"
+        "attribute.repository" = "assertion.repositoryUuid"
+        "attribute.git_ref" = "assertion.branchName"
+      }
+      oidc           = {
+        issuer = "https://api.bitbucket.org/2.0/workspaceName/goup/pipelines-config/identity/oidc"
+        allowed_audiences = ["default"] # (or don't define the block)
+      }
+      attribute_condition = "assertion.workspaceUuid=='${some-uuid}'"
+    }
+  }
+}
+```

--- a/gcp/iam/workload_identity_federation/README.md
+++ b/gcp/iam/workload_identity_federation/README.md
@@ -1,6 +1,6 @@
 # Workload Identity Federation
 
-This module deploys a Workload Identity Pool, and it's Workload Identity Pool Providers (IDPs), for Workload Identity Federation.
+This module deploys a Workload Identity Pool (WIP), and it's Providers (WIP Providers), for Workload Identity Federation.
 [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation) allows external entities
 to access Google Cloud resources without using service account keys.
 
@@ -16,96 +16,98 @@ See the [configuration](#configuration) section for implementation details.
 
 ## Configuration
 This module takes the following variables:
-* `project_id` - The project the pool is defined in
-* `workload_identity_pool` - Definition of a pool and its providers with the following attributes:
+* `project_id` - The project the WIP is created in
+* `pool_id` - ID for the WIP 
+* `display_name` (optional) - The display name for the WIP, if different than the pool_id
+* `description` (optional) - Description for the WIP
+* `disabled` (optional) - Whether the WIP is disabled (default `false`)
+* `workload_identity_pool_providers` - A map of WIP providers, with the provider ID's as the keys and the following 
+attributes:
 
-| Key                                |     Type     | Required | Description                                                                                                                                       |                                                           Default                                                           |
-|:-----------------------------------|:------------:|:--------:|:--------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------:|
-| `pool_id`                          |    string    |   true   | ID for the pool                                                                                                                                   |                                                            none                                                             |
-| `display_name`                     |    string    |  false   | The display name of the pool if different than the pool-id                                                                                        |                                                           pool-id                                                           |
-| `description`                      |    string    |  false   | Description for the pool                                                                                                                          |                                                            none                                                             |
-| `disabled`                         |     bool     |  false   | Whether the pool is disabled                                                                                                                      |                                                            false                                                            |
-| `providers`                        | map(object)  |  false   | Map with of provider-id and it's attributes                                                                                                       |                                                            none                                                             |
-| `providers.attribute_mapping`      | map(string)  |  false   | Maps attributes from OIDC claim to google attributes. `google.sub` is required, e.g. `google.sub=assertion.sub`                                   |                                                            none                                                             |
-| `providers.display_name`           |    string    |  false   | Display name for the provider                                                                                                                     |                                                         provider-id                                                         |
-| `providers.description`            |    string    |  false   | Description for the provider                                                                                                                      |                                                            none                                                             |
-| `providers.disabled`               |     bool     |  false   | Whether the provider is disabled                                                                                                                  |                                                            false                                                            |
-| `providers.attribute_condition`    |    string    |  false   | An expression to define required values for assertion claims                                                                                      |                                                            none                                                             |
-| `providers.owner`                  |    string    |  false   | If using a preconfigured `providers.oidc.issuer` this references the "owner" of the issuer, i.e. the organization or username.                    |                                                            none                                                             |
-| `providers.workspace_uuid`         |    string    |  false   | If `providers.oidc.issuer` is `bitbucket-pipelines`, this references the workspace uuid with the format: `{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}` |                                                            none                                                             |
-| `providers.oidc`                   |     map      |  false   | The configuration for an OIDC provider (Either this OR `aws` block can be set)                                                                    |                                                            none                                                             |
-| `providers.oidc.issuer`            |    string    |   true   | The preconfigured template to use, or the OIDC issuer uri                                                                                         |                                                            none                                                             |
-| `providers.oidc.allowed_audiences` | list(string) |  false   | Acceptable values for the `aud` field                                                                                                             | `"https://iam.googleapis.com/projects/project-number/locations/global/workloadIdentityPools/pool-id/providers/provider-id"` |
-| `providers.aws`                    |     map      |  false   | The configuration for an AWS provider (Either this OR `oidc` block can be set)                                                                    |                                                            none                                                             |
-| `providersaws.account_id`          |     map      |   true   | The id of the client aws account                                                                                                                  |                                                            none                                                             |
+| Key                      |     Type     | Required | Description                                                                                                                             |                                                           Default                                                           |
+|:-------------------------|:------------:|:--------:|:----------------------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------:|
+| `attribute_mapping`      | map(string)  |  false   | Maps attributes from OIDC claim to google attributes. `google.sub` is required, e.g. `google.sub=assertion.sub`                         |                                                            none                                                             |
+| `display_name`           |    string    |  false   | Display name for the provider                                                                                                           |                                                         provider-id                                                         |
+| `description`            |    string    |  false   | Description for the provider                                                                                                            |                                                            none                                                             |
+| `disabled`               |     bool     |  false   | Whether the provider is disabled                                                                                                        |                                                            false                                                            |
+| `attribute_condition`    |    string    |  false   | An expression to define required values for assertion claims                                                                            |                                                            none                                                             |
+| `owner`                  |    string    |  false   | If using a preconfigured `oidc.issuer` this references the "owner" of the issuer, i.e. the organization or username.                    |                                                            none                                                             |
+| `workspace_uuid`         |    string    |  false   | If `oidc.issuer` is `bitbucket-pipelines`, this references the workspace uuid with the format: `{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}` |                                                            none                                                             |
+| `oidc`                   |     map      |  false   | The configuration for an OIDC provider (Either this OR `aws` block can be set)                                                          |                                                            none                                                             |
+| `oidc.issuer`            |    string    |   true   | The preconfigured template to use, or the OIDC issuer uri                                                                               |                                                            none                                                             |
+| `oidc.allowed_audiences` | list(string) |  false   | Acceptable values for the `aud` field                                                                                                   | `"https://iam.googleapis.com/projects/project-number/locations/global/workloadIdentityPools/pool-id/providers/provider-id"` |
+| `aws`                    |     map      |  false   | The configuration for an AWS provider (Either this OR `oidc` block can be set)                                                          |                                                            none                                                             |
+| `aws.account_id`         |     map      |   true   | The id of the client aws account                                                                                                        |                                                            none                                                             |
 
 #### Example
 ```terraform
 module workload_identity_pool {
   source                 = "github.com/mesoform/terraform-infrastructure-modules//gcp/iam/workload_identity_federation"
   project_id             = "project_id"
-  workload_identity_pool = {
-    pool_id   = "cicd"
-    display_name = "CI/CD pool"
-    providers = {
-      github = {
-        attribute_condition = "assertion.repostory_owner=='Company' && assertion.actor=='personalAccount'"
-        attribute_mapping   = {
-          "google.subject"  = "assertion.repository"
-        }
-        owner = "Company"
-        oidc  = {
-          issuer = "github-actions"
-        }
+  pool_id = "cicd"
+  display_name = "CI/CD pool"
+  workload_identity_pool_providers = {
+    github-company1 = {
+      attribute_condition = "assertion.repostory_owner=='company1' && assertion.actor=='personalAccount'"
+      attribute_mapping   = {
+        "google.subject"  = "assertion.repository"
       }
-      bitbucket = {
-        owner          = "mesoform"
-        workspace_uuid = "{some-uuid}"
-        oidc           = {
-          issuer = "bitbucket-pipelines"
-        }
-      }
-      unknown = {
-        attribute_mapping = {
-          "google.subject" = "assertion.sub"
-          "attribute.tid"  = "assertion.tid"
-        }
-        oidc = {
-          issuer = "https://unknown.issuer"
-        }
+      owner = "company1"
+      oidc  = {
+        issuer = "github-actions"
       }
     }
-  }
+    bitbucket-mesoform = {
+       owner          = "mesoform"
+      workspace_uuid = "{some-uuid}"
+      oidc           = {
+        issuer = "bitbucket-pipelines"
+      }
+    }
+    unknown = {
+      attribute_mapping = {
+        "google.subject" = "assertion.sub"
+        "attribute.tid"  = "assertion.tid"
+      }
+      oidc = {
+        issuer = "https://unknown.issuer"
+      }
+    }
+  } 
 }
 ```
 
 Multiple pools can be configured at once using a `for_each` attribute, e.g.:
 ```terraform
 module workload_identity_pools {
-  source                 = "github.com/mesoform/terraform-infrastructure-modules//gcp/iam/workload_identity_federation"
-  for_each               = var.workload_identity_pools
-  project_id             = var.project_id
-  workload_identity_pool = each.value
+  source                           = "github.com/mesoform/terraform-infrastructure-modules//gcp/iam/workload_identity_federation"
+  for_each                         = var.workload_identity_pools
+  project_id                       = var.project_id
+  pool_id                          = each.value.pool_id
+  display_name                     = lookup(each.value, "display_name", null)
+  description                      = lookup(each.value, "description", "")
+  workload_identity_pool_providers = lookup(each.value, "providers", null)
 }
 ```
-where `var.workload_identity_pools` is set as:
+where `var.workload_identity_pools` is defined as:
 ```terraform
 workload_identity_pools = {
   cicd = {
     pool_id      = "cicd"
     display_name = "CI/CD pool"
     providers    = {
-      github = {
-        attribute_condition = "assertion.repostory_owner=='Company' && assertion.actor=='personalAccount'"
+      github-company1 = {
+        display_name = "Company1 Github"
+        attribute_condition = "assertion.repostory_owner=='company1' && assertion.actor=='personalAccount'"
         attribute_mapping   = {
           "google.subject" = "assertion.repository"
         }
-        owner = "Company"
+        owner = "company1"
         oidc  = {
           issuer = "github-actions"
         }
       }
-      bitbucket = {
+      bitbucket-mesoform = {
         owner          = "mesoform"
         workspace_uuid = "{some-uuid}"
         oidc           = {
@@ -149,7 +151,7 @@ This module has preconfigured Identity Provider settings for commonly used clien
 which can be used by setting `providers.oidc.issuer` to one of the issuers from the table below, 
 as well as setting the required attributes for the `workload_identity_pools` provider.
 
-Full defaults for preconfigured IDP can be found in the [`trusted_issuers.tf`](./trusted_issuers.yaml) file.
+Full defaults for preconfigured WIP Provider can be found in the [`trusted_issuers.tf`](./trusted_issuers.yaml) file.
 
 #### Trusted issuers
 | Issuer                | Required variable value                                                               |

--- a/gcp/iam/workload_identity_federation/README.md
+++ b/gcp/iam/workload_identity_federation/README.md
@@ -146,12 +146,13 @@ workload_identity_pools = {
 
 ### Preconfigured defaults
 This module has preconfigured Identity Provider settings for commonly used clients, referred to as "trusted issuers",
-which can be used by setting `providers.oidc.issuer` to one of the issuers from the table below, as well as setting required MCCF attributes.
+which can be used by setting `providers.oidc.issuer` to one of the issuers from the table below, 
+as well as setting the required attributes for the `workload_identity_pools` provider.
 
 Full defaults for preconfigured IDP can be found in the [`trusted_issuers.tf`](./trusted_issuers.yaml) file.
 
 #### Trusted issuers
-| Issuer                | Required MCCF attributes                                                              |
+| Issuer                | Required variable value                                                               |
 |-----------------------|---------------------------------------------------------------------------------------|
 | `azure`               | - `owner`: Tenant ID of Azure tenant                                                  |
 | `bitbucket-pipelines` | - `owner`: Name of the workspace owner <br> - `workspace_uuid`: UUid of the workspace |

--- a/gcp/iam/workload_identity_federation/README.md
+++ b/gcp/iam/workload_identity_federation/README.md
@@ -161,12 +161,26 @@ Full defaults for preconfigured IDP can be found in the [`trusted_issuers.tf`](.
 | `gitlab`              | - `owner`: Unique group ID                                                            |
 | `terraform-cloud`     | - `owner`: Terraform Cloud Organization ID                                            |
 
-Each of the providers have a condition configured based on the `owner`/`workspace_uuid` attributes.
+#### Changing default values
+##### attribute_mapping:
+The `attribute_mapping` values can be overwritten by specifying a different value for preconfigured keys.
+If a preconfigured key is unwanted it can be set to null, e.g. `"attribute.git_ref" = null`.
+
+##### attribute_condition:
+Each of the providers have a condition configured based on the `owner`/`workspace_uuid` attributes, 
+ensuring .
 To make a custom condition configure set the `attribute_condition` to a [valid condition](https://cloud.google.com/iam/docs/workload-identity-federation#conditions).
 
-Some of these issuers have a configured default audience different to the Google default
+> **WARNING**: Some claims don't include the unique attributes, so tokens issued by other owners could have similar values. 
+> If the condition is not appropriately set to limit access, 
+> other users or users outside your organization could end up with access to your resources
+
+##### audience:
+The client's audience is extracted from the `aud` claim in the token, and by default is expected to be the address of the resource server
 (i.e. `https://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/POOL_ID/providers/PROVIDER_ID`).
-If this Google default audience should be included in the `allowed_audiences` as well as the preconfigured default,
+Some tokens, provided by some of the above issuers, have a different default `aud` value specified, 
+so the preconfigured `allowed_audiences` attribute is set to match that.
+If the default audience should be included in the `allowed_audiences` as well as the preconfigured default,
 add `"default"` to the list in `oidc.allowed_audiences`.   
 e.g.
 ```terraform

--- a/gcp/iam/workload_identity_federation/dependencies.tf
+++ b/gcp/iam/workload_identity_federation/dependencies.tf
@@ -1,0 +1,7 @@
+data google_project self {
+  project_id = var.project_id
+}
+
+locals {
+  default_audience = "https://iam.googleapis.com/projects/${data.google_project.self.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.self.id}/providers/%s"
+}

--- a/gcp/iam/workload_identity_federation/locals.tf
+++ b/gcp/iam/workload_identity_federation/locals.tf
@@ -1,0 +1,43 @@
+locals  {
+  trusted_issuers_file = "${path.module}/trusted_issuers.yaml"
+
+  identity_pool_providers_map_trusted = {
+    for provider, specs in var.workload_identity_pool.providers: provider =>
+      contains(keys(yamldecode(file(local.trusted_issuers_file))), try(specs.oidc.issuer, "null")) ? yamldecode(
+        templatefile(local.trusted_issuers_file, {
+          owner = specs.owner
+          workspace_uuid = specs.workspace_uuid
+        } ))[specs.oidc.issuer] : null
+  }
+
+  identity_pool_providers = {
+    for provider, specs in var.workload_identity_pool.providers: provider => {
+      project = var.project_id
+      provider_id = provider
+      display_name = lookup(specs, "display_name", provider)
+      description = specs.description
+      disabled = specs.disabled
+      attribute_mapping = merge(
+        lookup(local.identity_pool_providers_map_trusted, provider, null) == null ? {} : lookup(local.identity_pool_providers_map_trusted[provider], "attributes", {} ),
+        lookup(specs, "attribute_mapping", {})
+      )
+      //noinspection HILUnresolvedReference
+      attribute_condition = lookup(specs, "attribute_condition", null) == null ? try(
+        local.identity_pool_providers_map_trusted[provider].condition,
+        null
+      ) : specs.attribute_condition
+      oidc = lookup(specs, "oidc", null) == null ? null : {
+        //noinspection HILUnresolvedReference
+        issuer = lookup(local.identity_pool_providers_map_trusted, provider, null) == null ? specs.oidc.issuer : local.identity_pool_providers_map_trusted[provider].issuer
+        //noinspection HILUnresolvedReference
+        allowed_audiences = distinct(concat(
+          try(local.identity_pool_providers_map_trusted[provider].allowed_audiences, []),
+          specs.oidc.allowed_audiences
+        ))
+      }
+      aws = lookup(specs, "aws", null) == null ? null : {
+        account_id = specs.aws.account_id
+      }
+    }
+  }
+}

--- a/gcp/iam/workload_identity_federation/locals.tf
+++ b/gcp/iam/workload_identity_federation/locals.tf
@@ -2,7 +2,7 @@ locals  {
   trusted_issuers_file = "${path.module}/trusted_issuers.yaml"
 
   identity_pool_providers_map_trusted = {
-    for provider, specs in var.workload_identity_pool.providers: provider =>
+    for provider, specs in var.workload_identity_pool_providers: provider =>
       contains(keys(yamldecode(file(local.trusted_issuers_file))), try(specs.oidc.issuer, "null")) ? yamldecode(
         templatefile(local.trusted_issuers_file, {
           owner = specs.owner
@@ -11,7 +11,7 @@ locals  {
   }
 
   identity_pool_providers = {
-    for provider, specs in var.workload_identity_pool.providers: provider => {
+    for provider, specs in var.workload_identity_pool_providers: provider => {
       project = var.project_id
       provider_id = provider
       display_name = lookup(specs, "display_name", provider)

--- a/gcp/iam/workload_identity_federation/main.tf
+++ b/gcp/iam/workload_identity_federation/main.tf
@@ -1,9 +1,9 @@
 resource google_iam_workload_identity_pool self {
   project = data.google_project.self.project_id
-  workload_identity_pool_id = replace(var.workload_identity_pool.pool_id, "_", "-")
-  display_name = var.workload_identity_pool.display_name == null ?  var.workload_identity_pool.pool_id : var.workload_identity_pool.display_name
-  description = var.workload_identity_pool.description
-  disabled = var.workload_identity_pool.disabled
+  workload_identity_pool_id = replace(var.pool_id, "_", "-")
+  display_name = var.display_name == null ?  var.pool_id : var.display_name
+  description = var.description
+  disabled = var.disabled
 }
 
 //noinspection HILUnresolvedReference

--- a/gcp/iam/workload_identity_federation/main.tf
+++ b/gcp/iam/workload_identity_federation/main.tf
@@ -1,12 +1,3 @@
-data google_project self {
-  project_id = var.project_id
-
-}
-
-locals {
-  default_audience = "https://iam.googleapis.com/projects/${data.google_project.self.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.self.id}/providers/%s"
-}
-
 resource google_iam_workload_identity_pool self {
   project = data.google_project.self.project_id
   workload_identity_pool_id = replace(var.workload_identity_pool.pool_id, "_", "-")

--- a/gcp/iam/workload_identity_federation/main.tf
+++ b/gcp/iam/workload_identity_federation/main.tf
@@ -1,0 +1,48 @@
+data google_project self {
+  project_id = var.project_id
+
+}
+
+locals {
+  default_audience = "https://iam.googleapis.com/projects/${data.google_project.self.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.self.id}/providers/%s"
+}
+
+resource google_iam_workload_identity_pool self {
+  project = data.google_project.self.project_id
+  workload_identity_pool_id = replace(var.workload_identity_pool.pool_id, "_", "-")
+  display_name = var.workload_identity_pool.display_name == null ?  var.workload_identity_pool.pool_id : var.workload_identity_pool.display_name
+  description = var.workload_identity_pool.description
+  disabled = var.workload_identity_pool.disabled
+}
+
+//noinspection HILUnresolvedReference
+resource google_iam_workload_identity_pool_provider self {
+  for_each = local.identity_pool_providers
+  project = each.value.project
+  workload_identity_pool_id = google_iam_workload_identity_pool.self.workload_identity_pool_id
+  workload_identity_pool_provider_id = replace(each.value.provider_id, "_", "-")
+  display_name = each.value.display_name
+  description = each.value.description
+  disabled = each.value.disabled
+  attribute_mapping = each.value.attribute_mapping
+  attribute_condition = each.value.attribute_condition
+  //noinspection HILUnresolvedReference
+  dynamic "aws" {
+    for_each = lookup(each.value, "aws", null) == null ? {} : { aws = each.value.aws}
+    //noinspection HILUnresolvedReference
+    content {
+      account_id = aws.value.account_id
+    }
+  }
+  //noinspection HILUnresolvedReference
+  dynamic "oidc" {
+    for_each = lookup(each.value, "oidc", null) == null ? {} : { oidc = each.value.oidc }
+    //noinspection HILUnresolvedReference
+    content {
+      issuer_uri = oidc.value.issuer
+      allowed_audiences = [ for audience in lookup(oidc.value, "allowed_audiences", []):
+        (audience == "default" ? format(local.default_audience, replace(each.value.provider_id, "_", "-")) : audience)
+      ]
+    }
+  }
+}

--- a/gcp/iam/workload_identity_federation/outputs.tf
+++ b/gcp/iam/workload_identity_federation/outputs.tf
@@ -1,0 +1,3 @@
+output pool_id {
+  value = google_iam_workload_identity_pool.self.id
+}

--- a/gcp/iam/workload_identity_federation/trusted_issuers.yaml
+++ b/gcp/iam/workload_identity_federation/trusted_issuers.yaml
@@ -1,0 +1,52 @@
+azure:
+  issuer: "https://sts.windows.net/${owner}"
+  attributes:
+    "google.subject": "assertion.sub"
+    "google.groups": "assertion.groups"
+bitbucket-pipelines:
+  issuer: "https://api.bitbucket.org/2.0/workspaces/${owner}/pipelines-config/identity/oidc"
+  allowed_audiences:
+    - "ari:cloud:bitbucket::workspace/${workspace_uuid}"
+  attributes:
+    "google.subject": "assertion.sub"
+    "attribute.workspace_uuid": "assertion.workspaceUuid"
+    "attribute.repository": "assertion.repositoryUuid"
+    "attribute.git_ref": "assertion.branchName"
+  condition: "assertion.workspaceUuid=='${workspace_uuid}'"
+circleci:
+  issuer: "https://oidc.circleci.com/org/${owner}"
+  allowed_audiences:
+    - "${owner}"
+  attributes:
+    "google.subject": "assertion.sub"
+    "attribute.project_id": "assertion['oidc.circleci.com/project-id']"
+    "attribute.org_id": "assertion.aud"
+  condition: "assertion.aud=='${owner}'"
+github-actions:
+  issuer: "https://token.actions.githubusercontent.com"
+  attributes:
+    "google.subject": "assertion.sub"
+    "attribute.actor": "assertion.actor"
+    "attribute.repository": "assertion.repository"
+    "attribute.owner": "assertion.repository_owner"
+    "attribute.git_ref": "assertion.ref"
+  condition: "assertion.repository_owner=='${owner}'"
+gitlab:
+  issuer: "https://gitlab.com/"
+  allowed_audiences:
+    - "https://gitlab.com"
+  attributes:
+    "google.subject": "assertion.sub"
+    "attribute.namespace": "assertion.namespace_path"
+    "attribute.namespace_id": "assertion.namespace_id"
+    "attribute.project_id": "assertion.project_id"
+    "attribute.project_path": "assertion.project_path"
+  condition: "assertion.namespace_path=='${owner}'"
+terraform-cloud:
+  issuer: "https://app.terraform.io"
+  attributes:
+    "google.subject": "assertion.sub"
+    "attribute.organization": "assertion.terraform_organization_id"
+    "attribute.workspace_id": "assertion.terraform_workspace_id"
+    "attribute.workspace_name": "assertion.terraform_workspace_name"
+  condition: "assertion.terraform_organization_id=='${owner}'"

--- a/gcp/iam/workload_identity_federation/vars.tf
+++ b/gcp/iam/workload_identity_federation/vars.tf
@@ -1,0 +1,27 @@
+variable project_id {
+  type = string
+}
+
+variable workload_identity_pool {
+  type = object({
+    pool_id = string
+    display_name = optional(string, null)
+    description = optional(string, "")
+    disabled = optional(bool, false)
+    providers = optional(map(object({
+      attribute_mapping = optional(map(string))
+      attribute_condition = optional(string)
+      display_name = optional(string)
+      description = optional(string)
+      disabled = optional(bool, false)
+      aws = optional(map(string))
+      oidc = optional(object({
+        issuer = string
+        allowed_audiences = optional(list(string),[])
+      }))
+      owner = optional(string, "")
+      workspace_uuid = optional(string, "")
+    })), {})
+  })
+}
+

--- a/gcp/iam/workload_identity_federation/vars.tf
+++ b/gcp/iam/workload_identity_federation/vars.tf
@@ -1,27 +1,46 @@
 variable project_id {
+  description = "The project which the Workload Identity Pool will exist in"
   type = string
 }
 
-variable workload_identity_pool {
-  type = object({
-    pool_id = string
-    display_name = optional(string, null)
-    description = optional(string, "")
-    disabled = optional(bool, false)
-    providers = optional(map(object({
-      attribute_mapping = optional(map(string))
-      attribute_condition = optional(string)
-      display_name = optional(string)
-      description = optional(string)
-      disabled = optional(bool, false)
-      aws = optional(map(string))
-      oidc = optional(object({
-        issuer = string
-        allowed_audiences = optional(list(string),[])
-      }))
-      owner = optional(string, "")
-      workspace_uuid = optional(string, "")
-    })), {})
-  })
+variable pool_id {
+  description = "The id for the Workload Identity Pool"
+  type = string
 }
 
+variable display_name {
+  description = "Display name for the Workload Identity Pool (if different from the pool_id)"
+  type = string
+  default = null
+}
+
+variable description {
+  description = "Description for the Workload Identity Pool"
+  type = string
+  default = ""
+}
+
+variable disabled {
+  description = "Whether the Workload Identity Pool is disabled (default: false)"
+  type = bool
+  default = false
+}
+
+variable workload_identity_pool_providers {
+  description = "Map of Workload Identity Pool Providers and their settings"
+  type = map(object({
+    attribute_mapping = optional(map(string))
+    attribute_condition = optional(string)
+    display_name = optional(string)
+    description = optional(string)
+    disabled = optional(bool, false)
+    aws = optional(map(string))
+    oidc = optional(object({
+      issuer = string
+      allowed_audiences = optional(list(string),[])
+    }))
+    owner = optional(string, "")
+    workspace_uuid = optional(string, "")
+  }))
+  default = {}
+}

--- a/tests/gcp/unit_tests/workload_identity_federation/main.tf
+++ b/tests/gcp/unit_tests/workload_identity_federation/main.tf
@@ -1,0 +1,60 @@
+//noinspection HILUnresolvedReference
+data external test_oidc_provider_issuers {
+  query   = {
+    for provider, specs in local.identity_pool_providers :
+      provider => specs.oidc.issuer
+    if lookup(specs, "oidc", null) != null
+  }
+  program = ["python", "${path.module}/test_oidc_provider_issuers.py"]
+}
+output test_oidc_provider_issuers {
+  value = data.external.test_oidc_provider_issuers.result
+}
+
+//noinspection HILUnresolvedReference
+data external test_oidc_provider_audiences {
+  query   = {
+    for provider, specs in local.identity_pool_providers :
+      provider => join(", ", lookup(specs.oidc, "allowed_audiences", []))
+    if lookup(specs, "oidc", null) != null
+  }
+  program = ["python", "${path.module}/test_oidc_provider_audience.py"]
+}
+output test_oidc_provider_audiences {
+  value = data.external.test_oidc_provider_audiences.result
+}
+
+//noinspection HILUnresolvedReference
+data external test_provider_subject_attribute {
+  query   = {
+    for provider, specs in local.identity_pool_providers :
+      provider => specs.attribute_mapping["google.subject"]
+    if lookup(specs, "oidc", null) != null
+  }
+  program = ["python", "${path.module}/test_provider_subject_attribute.py"]
+}
+output test_provider_subject_attribute {
+  value = data.external.test_provider_subject_attribute.result
+}
+
+//noinspection HILUnresolvedReference
+data external test_oidc_provider_attributes {
+  query   = local.identity_pool_providers.bitbucket.attribute_mapping
+  program = ["python", "${path.module}/test_provider_attributes.py"]
+}
+output test_oidc_provider_attributes {
+  value = data.external.test_oidc_provider_attributes.result
+}
+
+//noinspection HILUnresolvedReference
+data external test_provider_conditions {
+  query   = {
+    for provider, specs in local.identity_pool_providers :
+      provider => lookup(specs, "attribute_condition", null) == null ? "none": specs.attribute_condition
+    if lookup(specs, "oidc", null) != null
+  }
+  program = ["python", "${path.module}/test_provider_conditions.py"]
+}
+output test_provider_conditions {
+  value = data.external.test_provider_conditions.result
+}

--- a/tests/gcp/unit_tests/workload_identity_federation/main.tf
+++ b/tests/gcp/unit_tests/workload_identity_federation/main.tf
@@ -39,7 +39,7 @@ output test_provider_subject_attribute {
 
 //noinspection HILUnresolvedReference
 data external test_oidc_provider_attributes {
-  query   = local.identity_pool_providers.bitbucket.attribute_mapping
+  query   = { for key, value in local.identity_pool_providers.bitbucket.attribute_mapping: key => value if value != null}
   program = ["python", "${path.module}/test_provider_attributes.py"]
 }
 output test_oidc_provider_attributes {

--- a/tests/gcp/unit_tests/workload_identity_federation/test.auto.tfvars
+++ b/tests/gcp/unit_tests/workload_identity_federation/test.auto.tfvars
@@ -1,0 +1,57 @@
+project_id = "project-id"
+workload_identity_pool = {
+  pool_id: "cicd"
+  providers = {
+    bitbucket = {
+      attribute_mapping = {
+        "google.subject" = "assertion.sub"
+        "attribute.tid"  = "assertion.tid"
+      }
+      owner = "companyWorkspace"
+      workspace_uuid = "{company-unique-id}"
+      oidc  = {
+        issuer = "bitbucket-pipelines"
+      }
+    }
+    circleci = {
+      owner = "company"
+      oidc = {
+        issuer = "circleci"
+      }
+    }
+    github = {
+      attribute_condition = "assertion.repository_owner=='companyOrg' && assertion.ref=='refs/head/main'"
+      attribute_mapping   = {
+        "google.subject"  = "overwrite.sub"
+        "attribute.actor" = "assertion.actor"
+        "attribute.aud"   = "assertion.aud"
+      }
+      owner = "companyOrg"
+      oidc  = {
+        issuer = "github-actions"
+      }
+    }
+    gitlab = {
+      owner = "companyGroup"
+      oidc = {
+        issuer = "gitlab"
+      }
+    }
+    terraform-cloud = {
+      owner = "organization"
+      oidc = {
+        issuer = "terraform-cloud"
+      }
+    }
+    unknown = {
+      attribute_mapping = {
+        "google.subject" = "assertion.other"
+        "attribute.tid"  = "assertion.tid"
+      }
+      oidc = {
+        issuer = "https://unknown.issuer"
+        allowed_audiences = ["audience1", "audience2"]
+      }
+    }
+  }
+}

--- a/tests/gcp/unit_tests/workload_identity_federation/test.auto.tfvars
+++ b/tests/gcp/unit_tests/workload_identity_federation/test.auto.tfvars
@@ -6,6 +6,7 @@ workload_identity_pool = {
       attribute_mapping = {
         "google.subject" = "assertion.sub"
         "attribute.tid"  = "assertion.tid"
+        "attribute.git_ref" = null
       }
       owner = "companyWorkspace"
       workspace_uuid = "{company-unique-id}"

--- a/tests/gcp/unit_tests/workload_identity_federation/test.auto.tfvars
+++ b/tests/gcp/unit_tests/workload_identity_federation/test.auto.tfvars
@@ -1,58 +1,57 @@
 project_id = "project-id"
-workload_identity_pool = {
-  pool_id: "cicd"
-  providers = {
-    bitbucket = {
-      attribute_mapping = {
-        "google.subject" = "assertion.sub"
-        "attribute.tid"  = "assertion.tid"
-        "attribute.git_ref" = null
-      }
-      owner = "companyWorkspace"
-      workspace_uuid = "{company-unique-id}"
-      oidc  = {
-        issuer = "bitbucket-pipelines"
-      }
+pool_id = "cicd"
+workload_identity_pool_providers = {
+  bitbucket = {
+    attribute_mapping = {
+      "google.subject" = "assertion.sub"
+      "attribute.tid"  = "assertion.tid"
+      "attribute.git_ref" = null
     }
-    circleci = {
-      owner = "company"
-      oidc = {
-        issuer = "circleci"
-      }
+    owner = "companyWorkspace"
+    workspace_uuid = "{company-unique-id}"
+    oidc  = {
+      issuer = "bitbucket-pipelines"
     }
-    github = {
-      attribute_condition = "assertion.repository_owner=='companyOrg' && assertion.ref=='refs/head/main'"
-      attribute_mapping   = {
-        "google.subject"  = "overwrite.sub"
-        "attribute.actor" = "assertion.actor"
-        "attribute.aud"   = "assertion.aud"
-      }
-      owner = "companyOrg"
-      oidc  = {
-        issuer = "github-actions"
-      }
+  }
+  circleci = {
+    owner = "company"
+    oidc = {
+      issuer = "circleci"
     }
-    gitlab = {
-      owner = "companyGroup"
-      oidc = {
-        issuer = "gitlab"
-      }
+  }
+  github = {
+    attribute_condition = "assertion.repository_owner=='companyOrg' && assertion.ref=='refs/head/main'"
+    attribute_mapping   = {
+      "google.subject"  = "overwrite.sub"
+      "attribute.actor" = "assertion.actor"
+      "attribute.aud"   = "assertion.aud"
     }
-    terraform-cloud = {
-      owner = "organization"
-      oidc = {
-        issuer = "terraform-cloud"
-      }
+    owner = "companyOrg"
+    oidc  = {
+      issuer = "github-actions"
     }
-    unknown = {
-      attribute_mapping = {
-        "google.subject" = "assertion.other"
-        "attribute.tid"  = "assertion.tid"
-      }
-      oidc = {
-        issuer = "https://unknown.issuer"
-        allowed_audiences = ["audience1", "audience2"]
-      }
+  }
+  gitlab = {
+    owner = "companyGroup"
+    oidc = {
+      issuer = "gitlab"
+    }
+  }
+  terraform-cloud = {
+    owner = "organization"
+    oidc = {
+      issuer = "terraform-cloud"
+    }
+  }
+  unknown = {
+    attribute_mapping = {
+      "google.subject" = "assertion.other"
+      "attribute.tid"  = "assertion.tid"
+    }
+    oidc = {
+      issuer = "https://unknown.issuer"
+      allowed_audiences = ["audience1", "audience2"]
     }
   }
 }
+

--- a/tests/gcp/unit_tests/workload_identity_federation/test_oidc_provider_audience.py
+++ b/tests/gcp/unit_tests/workload_identity_federation/test_oidc_provider_audience.py
@@ -1,0 +1,27 @@
+"""
+Terraform external provider just handles strings in maps, so tests need to consider this
+"""
+from sys import path, stderr
+
+try:
+    path.insert(1, '../../../test_fixtures/python_validator')
+    from python_validator import python_validator
+except Exception as e:
+    print(e, stderr)
+
+
+"""
+    Tests whether default audience from template are configured, and custom audiences set when specified.
+"""
+
+expected_data = {
+    "bitbucket": "ari:cloud:bitbucket::workspace/{company-unique-id}",
+    "circleci": "company",
+    "github": "",
+    "gitlab": "https://gitlab.com",
+    "terraform-cloud": "",
+    "unknown": "audience1, audience2"
+}
+
+if __name__ == '__main__':
+    python_validator(expected_data)

--- a/tests/gcp/unit_tests/workload_identity_federation/test_oidc_provider_issuers.py
+++ b/tests/gcp/unit_tests/workload_identity_federation/test_oidc_provider_issuers.py
@@ -1,0 +1,27 @@
+"""
+Terraform external provider just handles strings in maps, so tests need to consider this
+"""
+from sys import path, stderr
+
+try:
+    path.insert(1, '../../../test_fixtures/python_validator')
+    from python_validator import python_validator
+except Exception as e:
+    print(e, stderr)
+
+
+"""
+    Tests whether default issuer from templates are assigned correctly for each identity pool provider
+"""
+
+expected_data = {
+    "bitbucket": "https://api.bitbucket.org/2.0/workspaces/companyWorkspace/pipelines-config/identity/oidc",
+    "circleci": "https://oidc.circleci.com/org/company",
+    "github": "https://token.actions.githubusercontent.com",
+    "gitlab": "https://gitlab.com/",
+    "terraform-cloud": "https://app.terraform.io",
+    "unknown": "https://unknown.issuer"
+}
+
+if __name__ == '__main__':
+    python_validator(expected_data)

--- a/tests/gcp/unit_tests/workload_identity_federation/test_provider_attributes.py
+++ b/tests/gcp/unit_tests/workload_identity_federation/test_provider_attributes.py
@@ -1,0 +1,27 @@
+"""
+Terraform external provider just handles strings in maps, so tests need to consider this
+"""
+from sys import path, stderr
+
+try:
+    path.insert(1, '../../../test_fixtures/python_validator')
+    from python_validator import python_validator
+except Exception as e:
+    print(e, stderr)
+
+
+"""
+    Tests whether the attributes for the bitbucket provider include the default attributes from template, 
+    as well as ones explicitly set
+"""
+
+expected_data = {
+    "google.subject": "assertion.sub",
+    "attribute.workspace_uuid": "assertion.workspaceUuid",
+    "attribute.repository": "assertion.repositoryUuid",
+    "attribute.git_ref": "assertion.branchName",
+    "attribute.tid": "assertion.tid"
+}
+
+if __name__ == '__main__':
+    python_validator(expected_data)

--- a/tests/gcp/unit_tests/workload_identity_federation/test_provider_attributes.py
+++ b/tests/gcp/unit_tests/workload_identity_federation/test_provider_attributes.py
@@ -19,7 +19,6 @@ expected_data = {
     "google.subject": "assertion.sub",
     "attribute.workspace_uuid": "assertion.workspaceUuid",
     "attribute.repository": "assertion.repositoryUuid",
-    "attribute.git_ref": "assertion.branchName",
     "attribute.tid": "assertion.tid"
 }
 

--- a/tests/gcp/unit_tests/workload_identity_federation/test_provider_conditions.py
+++ b/tests/gcp/unit_tests/workload_identity_federation/test_provider_conditions.py
@@ -1,0 +1,27 @@
+"""
+Terraform external provider just handles strings in maps, so tests need to consider this
+"""
+from sys import path, stderr
+
+try:
+    path.insert(1, '../../../test_fixtures/python_validator')
+    from python_validator import python_validator
+except Exception as e:
+    print(e, stderr)
+
+
+"""
+    Tests whether the default conditions for each provider are configured to use the 'owner'
+"""
+
+expected_data = {
+    "bitbucket": "assertion.workspaceUuid=='{company-unique-id}'",
+    "circleci": "assertion.aud=='company'",
+    "github": "assertion.repository_owner=='companyOrg' && assertion.ref=='refs/head/main'",
+    "gitlab": "assertion.namespace_path=='companyGroup'",
+    "terraform-cloud": "assertion.terraform_organization_id=='organization'",
+    "unknown": "none"
+}
+
+if __name__ == '__main__':
+    python_validator(expected_data)

--- a/tests/gcp/unit_tests/workload_identity_federation/test_provider_subject_attribute.py
+++ b/tests/gcp/unit_tests/workload_identity_federation/test_provider_subject_attribute.py
@@ -1,0 +1,27 @@
+"""
+Terraform external provider just handles strings in maps, so tests need to consider this
+"""
+from sys import path, stderr
+
+try:
+    path.insert(1, '../../../test_fixtures/python_validator')
+    from python_validator import python_validator
+except Exception as e:
+    print(e, stderr)
+
+
+"""
+    Tests whether a google.sub attribute explicitly set by user will override ones in default template 
+"""
+
+expected_data = {
+    "bitbucket": "assertion.sub",
+    "circleci": "assertion.sub",
+    "github": "overwrite.sub",
+    "gitlab": "assertion.sub",
+    "terraform-cloud": "assertion.sub",
+    "unknown": "assertion.other"
+}
+
+if __name__ == '__main__':
+    python_validator(expected_data)

--- a/tests/gcp/unit_tests/workload_identity_federation/trusted_issuers.yaml
+++ b/tests/gcp/unit_tests/workload_identity_federation/trusted_issuers.yaml
@@ -1,0 +1,1 @@
+../../../../gcp/iam/workload_identity_federation/trusted_issuers.yaml

--- a/tests/gcp/unit_tests/workload_identity_federation/vars.tf
+++ b/tests/gcp/unit_tests/workload_identity_federation/vars.tf
@@ -1,0 +1,1 @@
+../../../../gcp/iam/workload_identity_federation/vars.tf

--- a/tests/gcp/unit_tests/workload_identity_federation/workload_identity_federation_locals.tf
+++ b/tests/gcp/unit_tests/workload_identity_federation/workload_identity_federation_locals.tf
@@ -1,0 +1,1 @@
+../../../../gcp/iam/workload_identity_federation/locals.tf


### PR DESCRIPTION
* Adds module which can be used for creating Workload Identity Pools and their Workload Identity Pool Providers.
  * Includes default configuration for identity pool providers with commonly known issuers (refered to as trusted issuers, and found in `workload_identity_pool/trusted_issuers.yaml` ([file](https://github.com/mesoform/terraform-infrastructure-modules/blob/feat/MPS-49/workload_identity_pool_module/gcp/iam/workload_identity_federation/trusted_issuers.yaml))
* Adds documentation on modules
* Adds unit tests for workload_identity_pool module 