### PR TITLE
Fix unit tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -32,13 +32,6 @@ jobs:
       with:
         terraform_wrapper: false
 
-    # Install gcloud sdk and set the service account
-    - name: Setup Cloud SDK
-      uses: google-github-actions/setup-gcloud@v0
-      with:
-        service_account_key: ${{secrets.GCP_SA_KEY}}
-        export_default_credentials: true
-
     # Run unit tests in GCP module
     - name: Run GCP unit tests
       run: |


### PR DESCRIPTION
Unit tests failed because they were using GCP_SA_KEY for setting up gcloud. gcloud is not necessary for unit tests so have removed the setup step