### PR TITLE
Updates serverless_neg_https_lb module ref version

### DIFF
--- a/gcp/compute_engine/serverless_neg_https_lb/main.tf
+++ b/gcp/compute_engine/serverless_neg_https_lb/main.tf
@@ -35,7 +35,7 @@ resource google_compute_region_network_endpoint_group cloud_function {
 }
 
 module serverless_neg_https_lb {
-  source  = "github.com/terraform-google-modules/terraform-google-lb-http//modules/serverless_negs?ref=v6.3.0"
+  source  = "github.com/terraform-google-modules/terraform-google-lb-http//modules/serverless_negs?ref=v9.3.0"
   project = var.project
   name = var.serverless_https_lb_name
   http_forward = var.serverless_https_lb_http_forward


### PR DESCRIPTION
Updates serverless_negs module version to v9.3.0 which is the first one allowing Terraform google provider version higher than v5:
https://github.com/terraform-google-modules/terraform-google-lb-http/blob/f8ce32e245a89658ea1cba1ca5b3363ab2ded7af/versions.tf