### PR TITLE
Add enable_private_path_for_google_cloud_services  for postgres module

### DIFF
--- a/gcp/databases/cloudsql/postgresql/main.tf
+++ b/gcp/databases/cloudsql/postgresql/main.tf
@@ -60,7 +60,7 @@ resource google_sql_database_instance default {
         private_network    = lookup(ip_configuration.value, "private_network", null)
         require_ssl        = lookup(ip_configuration.value, "require_ssl", true)
         allocated_ip_range = lookup(ip_configuration.value, "allocated_ip_range", null)
-
+        enable_private_path_for_google_cloud_services = lookup(ip_configuration.value, "enable_private_path_for_google_cloud_services", null)
         dynamic authorized_networks {
           for_each = lookup(ip_configuration.value, "authorized_networks", [])
           content {

--- a/gcp/databases/cloudsql/postgresql/read_replica.tf
+++ b/gcp/databases/cloudsql/postgresql/read_replica.tf
@@ -40,7 +40,7 @@ resource "google_sql_database_instance" "replicas" {
         private_network    = lookup(ip_configuration.value, "private_network", null)
         require_ssl        = lookup(ip_configuration.value, "require_ssl", null)
         allocated_ip_range = lookup(ip_configuration.value, "allocated_ip_range", null)
-
+        enable_private_path_for_google_cloud_services = lookup(ip_configuration.value, "enable_private_path_for_google_cloud_services", null)
         dynamic "authorized_networks" {
           for_each = lookup(ip_configuration.value, "authorized_networks", [])
           content {

--- a/gcp/databases/cloudsql/postgresql/variables.tf
+++ b/gcp/databases/cloudsql/postgresql/variables.tf
@@ -165,6 +165,7 @@ variable ip_configuration {
     private_network     = string
     require_ssl         = bool
     allocated_ip_range  = string
+    enable_private_path_for_google_cloud_services = bool
   })
   default = {
     authorized_networks = []
@@ -172,6 +173,7 @@ variable ip_configuration {
     private_network     = null
     require_ssl         = null
     allocated_ip_range  = null
+    enable_private_path_for_google_cloud_services = null
   }
 }
 
@@ -193,6 +195,7 @@ variable read_replicas {
       private_network     = string
       require_ssl         = bool
       allocated_ip_range  = string
+      enable_private_path_for_google_cloud_services = bool
     })
     encryption_key_name = string
   }))

--- a/gcp/databases/cloudsql/private_postgres/main.tf
+++ b/gcp/databases/cloudsql/private_postgres/main.tf
@@ -32,6 +32,7 @@ module cloudsql-postgres {
     private_network = data.google_compute_network.main.id
     require_ssl = var.cloudsql_require_ssl
     allocated_ip_range = null
+    enable_private_path_for_google_cloud_services = var.enable_private_path_for_google_cloud_services
   }
 
   backup_configuration = {

--- a/gcp/databases/cloudsql/private_postgres/variables.tf
+++ b/gcp/databases/cloudsql/private_postgres/variables.tf
@@ -188,4 +188,5 @@ variable cloudsql_availability_type {
 variable enable_private_path_for_google_cloud_services {
   description = "Whether to enable private path for google services (e.g. BigQuery) to connect to primary instance"
   default = null
+  type = bool
 }

--- a/gcp/databases/cloudsql/private_postgres/variables.tf
+++ b/gcp/databases/cloudsql/private_postgres/variables.tf
@@ -160,6 +160,7 @@ variable read_replicas {
       private_network     = string
       require_ssl         = bool
       allocated_ip_range  = string
+      enable_private_path_for_google_cloud_services = optional(bool, false)
     })
     encryption_key_name = string
   }))
@@ -182,4 +183,9 @@ variable cloudsql_availability_type {
   description = "The availability type of the Cloud SQL instance. Can be ZONAL or REGIONAL."
   type        = string
   default     = "ZONAL"
+}
+
+variable enable_private_path_for_google_cloud_services {
+  description = "Whether to enable private path for google services (e.g. BigQuery) to connect to primary instance"
+  default = null
 }


### PR DESCRIPTION
This PR adds the ability to configure the enable_private_path_for_google_cloud_services  property for postgres CloudSQL databases, which allows connectivity to private databases from Google private services like Big Query
## Changes
* In `private_postgres` modules adds `enable_private_path_for_google_cloud_services ` variable, to enable enable private access within primary database instance

## Breaking Changes
* In `postgres` module, adds `enable_private_path_for_google_cloud_services` property to `ip_configuration` variable object. Though default is null if `ip_configuration` block is not specified, if `ip_configuration` is specified without the new property there will be failure, so it should be set to `false` or `null` if not wanting it enabled  
* In `postgres` module, adds `ip_configuration.enable_private_path_for_google_cloud_services` property to `read_replicas` variable object. Though default is null if `ip_configuration` block is not specified, if `ip_configuration` is specified without the new property there will be failure, so it should be set to `false` or `null` if not wanting it enabled
* In `private_postgres` module adds `enable_private_path_for_google_cloud_services` attribute to `read_replicas` variable (`read_replica.ip_configuration.enable_private_path_for_google_cloud_services`), which is set as type `optional(bool)`. 
If using terraform version 1.3+ this feature is readily available, but for versions 0.15-1.2 the experimental feature must be enabled:  
  ```terraform
  terraform {
    experiments = [module_variable_optional_attrs]
  }
  ```