### PR TITLE
Add CMEK support for cross-region replicas

### DIFF
--- a/gcp/databases/cloudsql/postgresql/read_replica.tf
+++ b/gcp/databases/cloudsql/postgresql/read_replica.tf
@@ -88,8 +88,7 @@ resource "google_sql_database_instance" "replicas" {
   lifecycle {
     ignore_changes = [
       settings[0].disk_size,
-      settings[0].maintenance_window,
-      encryption_key_name,
+      settings[0].maintenance_window
     ]
   }
 

--- a/gcp/databases/cloudsql/private_postgres/main.tf
+++ b/gcp/databases/cloudsql/private_postgres/main.tf
@@ -54,6 +54,8 @@ module cloudsql-postgres {
   secret_manager_project_id = var.secret_manager_project_id
   secret_manager_location = var.secret_manager_location
 
+  encryption_key_name = var.encryption_key_name
+
   read_replicas                    = var.read_replicas
   read_replica_name_suffix         = var.read_replica_name_suffix
   read_replica_deletion_protection = var.read_replica_deletion_protection

--- a/gcp/databases/cloudsql/private_postgres/variables.tf
+++ b/gcp/databases/cloudsql/private_postgres/variables.tf
@@ -190,3 +190,9 @@ variable enable_private_path_for_google_cloud_services {
   default = null
   type = bool
 }
+
+variable encryption_key_name {
+  description = "The self-link of the KMS key to use for encryption."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Enhances the Cloud SQL module to support Customer-Managed Encryption Keys (CMEK), a prerequisite for creating cross-region read replicas.

- The `private_postgres` wrapper module now accepts an `encryption_key_name` variable and passes it to the underlying `postgresql` module.
- Removed `encryption_key_name` from the replica's `ignore_changes` lifecycle block to allow Terraform to manage the key for cross-region replication.