### PR TITLE
 Postgres module additional secrets

### DIFF
--- a/gcp/databases/cloudsql/postgresql/main.tf
+++ b/gcp/databases/cloudsql/postgresql/main.tf
@@ -133,6 +133,15 @@ module secret-manager-db-host-ip {
   depends_on = [null_resource.module_depends_on, google_sql_database_instance.default]
 }
 
+module secret-manager-db-connection-name {
+  source = "../../../secret_manager"
+  project = var.secret_manager_project_id
+  location = var.secret_manager_location
+  secret_id = "db-connection-name"
+  secret_data = google_sql_database_instance.default.connection_name
+  depends_on = [null_resource.module_depends_on, google_sql_database_instance.default]
+}
+
 module secret-manager-db-server-ca-cert {
   source = "../../../secret_manager"
   project = var.secret_manager_project_id

--- a/gcp/databases/cloudsql/postgresql/read_replica.tf
+++ b/gcp/databases/cloudsql/postgresql/read_replica.tf
@@ -98,3 +98,33 @@ resource "google_sql_database_instance" "replicas" {
     delete = var.delete_timeout
   }
 }
+
+module secret-manager-db-replica-server-ca-cert {
+  source = "../../../secret_manager"
+  for_each = local.replicas
+  project = var.secret_manager_project_id
+  location = var.secret_manager_location
+  secret_id = "db-replica-${each.key}-server-ca-cert"
+  secret_data = google_sql_database_instance.replicas[each.key].server_ca_cert.0.cert
+  depends_on = [null_resource.module_depends_on, google_sql_database_instance.replicas]
+}
+
+module secret-manager-db-replica-host-ip {
+  source = "../../../secret_manager"
+  for_each = local.replicas
+  project = var.secret_manager_project_id
+  location = var.secret_manager_location
+  secret_id = "db-replica-${each.key}-host-ip"
+  secret_data = google_sql_database_instance.replicas[each.key].private_ip_address
+  depends_on = [null_resource.module_depends_on, google_sql_database_instance.replicas]
+}
+
+module secret-manager-db-replica-connection-name {
+  source = "../../../secret_manager"
+  for_each = local.replicas
+  project = var.secret_manager_project_id
+  location = var.secret_manager_location
+  secret_id = "db-replica-${each.key}-connection-name"
+  secret_data = google_sql_database_instance.replicas[each.key].connection_name
+  depends_on = [null_resource.module_depends_on, google_sql_database_instance.replicas]
+}


### PR DESCRIPTION
Currently the postgres module does not create secrets for the read replica instance that would be used for connectivity. This PR adds secrets for the replicas and adds an addional connection-name secret for the primary instance and the replica as well.

Changes:  
* Adds `db-connection-name` secret storing the connection string (has the format `PROJECT:REGION:INSTANCE`)
* For each read replica, adds the following secrets:
  * `db-replica-${REPLICA_NAME}-server-ca-cert` 
  * `db-replica-${REPLICA_NAME}-server-host-ip` 
  * `db-replica-${REPLICA_NAME}-server-connection-name` 